### PR TITLE
Clarify video action button tooltips

### DIFF
--- a/lib/widgets/video_list_tile.dart
+++ b/lib/widgets/video_list_tile.dart
@@ -100,7 +100,7 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
             );
             ref.read(offlineVideosProvider.notifier).refresh();
           },
-          tooltip: 'Save offline',
+          tooltip: 'Save for offline',
         );
       case VideoStatus.downloading:
       case VideoStatus.pending:
@@ -140,7 +140,7 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
             color: NullFeedTheme.primaryColor,
           ),
           onPressed: widget.onDownload,
-          tooltip: 'Download',
+          tooltip: 'Download to server',
         );
       case VideoStatus.failed:
         return IconButton(


### PR DESCRIPTION
## Summary
- **CATALOGED** tooltip: "Download" → "Download to server" — clarifies this triggers a server-side download, not a local save
- **COMPLETE** (not offline) tooltip: "Save offline" → "Save for offline" — minor wording improvement for consistency

Part of cross-app effort to unify video status terminology between tvOS and Flutter.

## Test plan
- [ ] Build and run iOS app
- [ ] Long-press download button on a CATALOGED video — tooltip should say "Download to server"
- [ ] Long-press save button on a COMPLETE video — tooltip should say "Save for offline"

🤖 Generated with [Claude Code](https://claude.com/claude-code)