### PR TITLE
TestFlight: build with Xcode 26 (new App Store Connect requirement)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   beta:
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: read
     steps:
@@ -42,15 +42,19 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
-      - name: Select Xcode 16 (iOS 18 SDK)
+      # App Store Connect requires the iOS 26 SDK (Xcode 26) for uploads
+      # as of June 2026.
+      - name: Select Xcode 26 (iOS 26 SDK)
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16"
+          xcode-version: "26"
 
+      # Pinned to the same version CI validates (FLUTTER_VERSION in ci.yml)
+      # so the shipped binary is built with the toolchain that was tested.
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: "stable"
+          flutter-version: "3.41.4"
           cache: true
 
       - name: Install dependencies and generate code


### PR DESCRIPTION
The TestFlight deploy for the #24 merge failed at upload validation:

> SDK version issue. This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later.

The deploy job was pinned to Xcode 16 on `macos-15`. This moves it to `macos-26` + Xcode 26 (matching the CI Build iOS job's toolchain) and pins Flutter to 3.41.4 — the version CI validates — instead of floating `stable`, so the shipped binary is built with the toolchain that was tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)