### PR TITLE
Pull-to-refresh triggers a content poll

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -28,6 +28,7 @@ class AppConstants {
   static const String channels = '$apiBase/channels';
   static const String channelSubscribe = '$apiBase/channels/subscribe';
   static const String channelSubscribeBulk = '$apiBase/channels/subscribe-bulk';
+  static const String channelPollAll = '$apiBase/channels/poll';
   static const String videos = '$apiBase/videos';
   static const String activeDownloads = '$apiBase/videos/downloads';
   static const String feedContinueWatching = '$apiBase/feed/continue-watching';
@@ -40,6 +41,7 @@ class AppConstants {
   static String authProfile(String id) => '$apiBase/auth/profiles/$id';
   static String channelDetail(String id) => '$apiBase/channels/$id';
   static String channelVideos(String id) => '$apiBase/channels/$id/videos';
+  static String channelPoll(String id) => '$apiBase/channels/$id/poll';
   static String channelRefreshImages(String id) =>
       '$apiBase/channels/$id/refresh-images';
   static String channelUnsubscribe(String id) =>

--- a/lib/screens/channel_detail_screen.dart
+++ b/lib/screens/channel_detail_screen.dart
@@ -113,6 +113,14 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
   }
 
   Future<void> _refresh() async {
+    // Ask the server to check YouTube for new uploads first, so a pull
+    // down genuinely refreshes content rather than re-reading the catalog.
+    try {
+      await ref.read(apiServiceProvider).pollChannel(widget.channelId);
+    } catch (_) {
+      // Poll failures (offline server, YouTube hiccup) shouldn't block
+      // refreshing what we already have.
+    }
     try {
       await Future.wait([
         ref.refresh(channelDetailProvider(widget.channelId).future),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/feed.dart';
 import '../providers/feed_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../services/api_service.dart';
 import '../widgets/content_row.dart';
 import '../widgets/video_card.dart';
 import '../config/theme.dart';
@@ -58,6 +61,11 @@ class HomeScreen extends ConsumerWidget {
     );
 
     Future<void> refresh() async {
+      // Fire-and-forget: kick a server-side poll of all channels so new
+      // uploads start flowing in; results land via WS events / next refresh.
+      unawaited(
+        ref.read(apiServiceProvider).pollAllChannels().catchError((_) {}),
+      );
       try {
         await Future.wait([
           ref.refresh(continueWatchingProvider.future),

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -134,7 +134,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     return Scaffold(
       body: RefreshIndicator(
         color: NullFeedTheme.primaryColor,
-        onRefresh: () => ref.read(channelsProvider.notifier).load(),
+        onRefresh: () {
+          // Kick a server-side poll for new uploads alongside the reload.
+          unawaited(
+            ref.read(apiServiceProvider).pollAllChannels().catchError((_) {}),
+          );
+          return ref.read(channelsProvider.notifier).load();
+        },
         child: CustomScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
           slivers: [

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -287,6 +287,21 @@ class ApiService {
         .toList();
   });
 
+  /// Polls one channel for new uploads synchronously (server runs a single
+  /// yt-dlp call). Used by pull-to-refresh on the channel screen.
+  Future<void> pollChannel(String channelId) => _guard(() async {
+    await _dio.post(
+      '$_baseUrl${AppConstants.channelPoll(channelId)}',
+      options: Options(receiveTimeout: _slowReceiveTimeout),
+    );
+  });
+
+  /// Kicks off a background poll of all channels (fire-and-forget on the
+  /// server). Used by pull-to-refresh on home/library.
+  Future<void> pollAllChannels() => _guard(() async {
+    await _dio.post('$_baseUrl${AppConstants.channelPollAll}');
+  });
+
   Future<Channel> refreshChannelImages(String channelId) => _guard(() async {
     final response = await _dio.post(
       '$_baseUrl${AppConstants.channelRefreshImages(channelId)}',


### PR DESCRIPTION
Pulling down to refresh now actually checks YouTube for new content instead of just re-reading the server's catalog:

- **Channel detail** — refresh calls the new synchronous `POST /api/channels/{id}/poll`, so a new upload shows up in the same gesture
- **Home / Library** — refresh fires the background `POST /api/channels/poll` (all channels) alongside reloading; results land via WS events or the next refresh

Poll failures (server offline, YouTube hiccup) never block refreshing already-cached data. Pairs with windoze95/nullfeed-backend#65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)