### PR TITLE
Fix flaky Build iOS: drop the .dart_tool cache from the iOS build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,14 +107,12 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - name: Cache pub dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.pub-cache
-            .dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: pub-${{ runner.os }}-
+      # NOTE: deliberately no pub/.dart_tool cache for the iOS build.
+      # A restored .dart_tool carries stale native-assets fingerprints,
+      # which makes `flutter build ios` skip building FFI packages
+      # (objective_c) and fail with "native assets specification references
+      # objective_c, which was not found in build/native_assets/ios".
+      # Reproduced 2026-06-11: every cold build passed, every warm one failed.
 
       - name: Cache CocoaPods
         uses: actions/cache@v4


### PR DESCRIPTION
Build iOS started failing intermittently with:

> Exception: The native assets specification ... references objective_c, which was not found in build/native_assets/ios/

The pattern (4 runs today): every **cold-cache** build passed, every **warm-cache** build failed — same commit, same image, same dependency resolution. The cached `.dart_tool` carries native-assets build fingerprints, so on restore Flutter thinks objective_c's native library is already built and skips it.

Removes the pub/`.dart_tool` cache step from the Build iOS job only (~1 min slower, deterministic). Analyze/Test keep their caches — they don't run native builds and pass warm. Also deleted the currently-poisoned cache entries so in-flight PRs can rerun clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)