### PR TITLE
fix: delay VideoPlayerController disposal to avoid crash on HQ switch

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -321,8 +321,10 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
         _isPreviewMode = false;
       });
 
-      oldController?.pause();
-      oldController?.dispose();
+      Future.microtask(() {
+        oldController?.pause();
+        oldController?.dispose();
+      });
     } catch (e) {
       // HQ switch failed — keep playing preview (silent fallback)
       debugPrint('HQ switch failed, continuing preview: $e');
@@ -696,8 +698,8 @@ class _ControlsOverlay extends StatelessWidget {
                         height: 4,
                         onSeek: (fraction) {
                           final target = Duration(
-                            milliseconds: (fraction * duration.inMilliseconds)
-                                .round(),
+                            milliseconds:
+                                (fraction * duration.inMilliseconds).round(),
                           );
                           controller.seekTo(target);
                           onInteraction();


### PR DESCRIPTION
## Description\n\nWraps the old controller's pause/dispose in \Future.microtask()\ to ensure disposal happens after the current frame's widget tree has fully unmounted the old VideoPlayer widget.\n\n## Fixes\n\nFixes #19 — Crash on Synchronous VideoPlayerController Disposal\n\n## Root Cause\n\n\_switchToHq()\ was synchronously calling \oldController?.pause()\ and \oldController?.dispose()\ right after \setState()\. Since the widget tree hadn't finished unmounting the old \VideoPlayer\ widget in the same frame, attached listeners (\ValueListenableBuilder\) could still trigger updates on the disposed controller, causing an assertion error.