### PR TITLE
fix: remove await from progress save to unblock navigation on back

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -377,11 +377,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
 
   Future<void> _navigateBack() async {
     // Save progress before leaving, but never block navigation on a failure.
-    try {
-      await _saveProgress();
-    } catch (_) {
-      // Ignore — progress save is best-effort.
-    }
+    unawaited(_saveProgress().catchError((_) {}));
     _controller?.pause();
     if (mounted) {
       Navigator.of(context).pop();


### PR DESCRIPTION
## Description\n\nRemoves the \wait\ from \_saveProgress()\ in \_navigateBack()\ so the UI pops immediately without waiting for the network request.\n\n## Fixes\n\nFixes #12 — Exiting video player blocks UI navigation on network request