### PR TITLE
fix: throttle progress disk writes to every 500ms during download

### DIFF
--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -90,18 +90,23 @@ class OfflineService {
     onListChanged?.call();
 
     try {
+      var lastUpdate = DateTime.now().millisecondsSinceEpoch;
       await _dio.download(
         url,
         localPath,
         cancelToken: cancelToken,
         onReceiveProgress: (received, total) {
           if (total > 0) {
-            final progress = received / total;
-            _updateEntry(videoId, {
-              'progress': progress,
-              'file_size_bytes': total,
-            });
-            onProgress?.call(videoId, progress);
+            final now = DateTime.now().millisecondsSinceEpoch;
+            if (now - lastUpdate > 500 || received == total) {
+              lastUpdate = now;
+              final progress = received / total;
+              _updateEntry(videoId, {
+                'progress': progress,
+                'file_size_bytes': total,
+              });
+              onProgress?.call(videoId, progress);
+            }
           }
         },
       );


### PR DESCRIPTION
## Description\n\nThrottles Hive \_updateEntry\ calls in the \onReceiveProgress\ callback to at most once per 500ms, preventing excessive disk writes that cause severe UI stuttering and frame drops during fast downloads.\n\n## Fixes\n\nFixes #6 — Performance: Excessive disk writes during active download stream