### PR TITLE
fix: use ref.listen instead of whenData in build

### DIFF
--- a/lib/screens/channel_detail_screen.dart
+++ b/lib/screens/channel_detail_screen.dart
@@ -183,7 +183,10 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
     final progressMap = ref.watch(downloadProgressProvider);
     final padding = AdaptiveLayout.contentPadding(context);
 
-    videosAsync.whenData(_checkPollingNeeded);
+    ref.listen<AsyncValue<List<Video>>>(
+      channelVideosProvider(widget.channelId),
+      (_, next) => next.whenData(_checkPollingNeeded),
+    );
 
     return Scaffold(
       // The loaded state brings its own SliverAppBar; loading/error states


### PR DESCRIPTION
Replaces videosAsync.whenData with ref.listen to avoid modifying state during build phase.\n\nFixes #8