### PR TITLE
feat: keep screen awake during playback + home cards play the tapped video

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:video_player/video_player.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import '../models/video.dart';
 import '../providers/websocket_provider.dart';
 import '../services/api_service.dart';
@@ -142,6 +143,8 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       _controller = controller;
       _isInitialized = true;
     });
+    // Playback has started — keep the screen awake until the player closes.
+    unawaited(WakelockPlus.enable());
 
     _startProgressTimer();
     _scheduleHideControls();
@@ -193,6 +196,8 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       _isPreviewMode = isPreview;
     });
     _startingPlayback = false;
+    // Playback has started — keep the screen awake until the player closes.
+    unawaited(WakelockPlus.enable());
 
     // An HQ-ready event may have arrived while the preview was initializing.
     if (isPreview && _pendingHqSwitch) {
@@ -469,6 +474,8 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     }
     controller?.pause();
     controller?.dispose();
+    // Re-allow the screen to sleep now that playback is over.
+    unawaited(WakelockPlus.disable());
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     SystemChrome.setPreferredOrientations(DeviceOrientation.values);
     super.dispose();

--- a/lib/widgets/video_card.dart
+++ b/lib/widgets/video_card.dart
@@ -41,14 +41,18 @@ class _VideoCardState extends ConsumerState<VideoCard> {
   }
 
   Future<void> _onActivate() async {
-    if (widget.showProgress) {
-      await context.push('/player/${widget.video.id}');
-      // Watch positions likely changed — refresh the home feed rows.
-      if (!mounted) return;
-      invalidateFeedProviders(ref);
-    } else if (widget.channel != null) {
-      context.push('/channel/${widget.channel!.id}');
-    }
+    // Every home-feed card plays its video on tap; channel navigation lives
+    // on the channel sub-row below (see [_openChannel]).
+    await context.push('/player/${widget.video.id}');
+    // Watch positions likely changed — refresh the home feed rows.
+    if (!mounted) return;
+    invalidateFeedProviders(ref);
+  }
+
+  void _openChannel() {
+    final channel = widget.channel;
+    if (channel == null) return;
+    context.push('/channel/${channel.id}');
   }
 
   @override
@@ -223,31 +227,35 @@ class _VideoCardState extends ConsumerState<VideoCard> {
                 if (widget.channel != null)
                   Padding(
                     padding: const EdgeInsets.only(top: 4),
-                    child: Row(
-                      children: [
-                        if (widget.channel!.avatarUrl != null)
-                          Padding(
-                            padding: const EdgeInsets.only(right: 6),
-                            child: CircleAvatar(
-                              radius: 10,
-                              backgroundImage: CachedNetworkImageProvider(
-                                widget.channel!.avatarUrl!,
+                    child: GestureDetector(
+                      onTap: _openChannel,
+                      behavior: HitTestBehavior.opaque,
+                      child: Row(
+                        children: [
+                          if (widget.channel!.avatarUrl != null)
+                            Padding(
+                              padding: const EdgeInsets.only(right: 6),
+                              child: CircleAvatar(
+                                radius: 10,
+                                backgroundImage: CachedNetworkImageProvider(
+                                  widget.channel!.avatarUrl!,
+                                ),
+                                backgroundColor: NullFeedTheme.cardColor,
                               ),
-                              backgroundColor: NullFeedTheme.cardColor,
+                            ),
+                          Expanded(
+                            child: Text(
+                              widget.channel!.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: NullFeedTheme.textMuted,
+                                fontSize: 12,
+                              ),
                             ),
                           ),
-                        Expanded(
-                          child: Text(
-                            widget.channel!.name,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              color: NullFeedTheme.textMuted,
-                              fontSize: 12,
-                            ),
-                          ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   intl: ^0.20.2
   shimmer: ^3.0.0
   path_provider: ^2.1.0
+  wakelock_plus: ^1.6.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Two iOS playback/navigation UX improvements (roadmap NEXT tier).

## Keep the screen awake during playback
Added `wakelock_plus`; the iOS idle timer previously dimmed/locked the screen mid-video. Wakelock is enabled in both `_startPlayback` (network) and `_startOfflinePlayback` (offline) and disabled once in `dispose()` alongside the existing `SystemChrome` restore — symmetric and idempotent, and it intentionally stays on across the preview→HQ controller swap.

## Home-feed cards play the tapped video
Previously only Continue Watching cards played; tapping a New Episodes / Recently Added card opened the **channel** instead (with a misleading play overlay). Now every home card plays its video on tap (`_onActivate` → `/player/:id`), and channel navigation moved to the channel avatar/name sub-row via a nested opaque `GestureDetector` (the gesture arena awards sub-row taps to the inner detector). Continue Watching behavior is unchanged.

## Verification
- `dart format .` — clean
- `flutter analyze --fatal-infos --fatal-warnings` — No issues found
- `flutter test` — 72 passed

Note: channel navigation from a card is touch-only (the primary select action always plays), which fits the iOS touch app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY