### PR TITLE
feat: consume unified home feed, error code, and live progress events

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -31,6 +31,7 @@ class AppConstants {
   static const String channelPollAll = '$apiBase/channels/poll';
   static const String videos = '$apiBase/videos';
   static const String activeDownloads = '$apiBase/videos/downloads';
+  static const String feedHome = '$apiBase/feed/home';
   static const String feedContinueWatching = '$apiBase/feed/continue-watching';
   static const String feedNewEpisodes = '$apiBase/feed/new-episodes';
   static const String feedRecentlyAdded = '$apiBase/feed/recently-added';

--- a/lib/providers/feed_provider.dart
+++ b/lib/providers/feed_provider.dart
@@ -17,22 +17,21 @@ final recentlyAddedProvider = FutureProvider<List<FeedItem>>((ref) async {
   return api.getRecentlyAdded();
 });
 
-/// Refreshes the three home-feed rows. Call after returning from the player
-/// (any entry point) — watch positions have likely changed.
+/// Refreshes the home feed. [homeFeedProvider] backs the home screen (one
+/// request); the per-row providers stay invalidated for any surface still
+/// reading them individually. Call after returning from the player (any entry
+/// point) — watch positions have likely changed.
 void invalidateFeedProviders(WidgetRef ref) {
+  ref.invalidate(homeFeedProvider);
   ref.invalidate(continueWatchingProvider);
   ref.invalidate(newEpisodesProvider);
   ref.invalidate(recentlyAddedProvider);
 }
 
+/// The unified home feed (all three rows in a single request). This is what
+/// the home screen watches; [continueWatchingProvider] and friends remain for
+/// callers that need one row at a time.
 final homeFeedProvider = FutureProvider<HomeFeed>((ref) async {
-  final continueWatching = await ref.watch(continueWatchingProvider.future);
-  final newEpisodes = await ref.watch(newEpisodesProvider.future);
-  final recentlyAdded = await ref.watch(recentlyAddedProvider.future);
-
-  return HomeFeed(
-    continueWatching: continueWatching,
-    newEpisodes: newEpisodes,
-    recentlyAdded: recentlyAdded,
-  );
+  final api = ref.watch(apiServiceProvider);
+  return api.getHomeFeed();
 });

--- a/lib/providers/websocket_provider.dart
+++ b/lib/providers/websocket_provider.dart
@@ -58,6 +58,7 @@ final webSocketConnectionProvider = Provider<void>((ref) {
         ref.invalidate(continueWatchingProvider);
         ref.invalidate(newEpisodesProvider);
         ref.invalidate(recentlyAddedProvider);
+        ref.invalidate(homeFeedProvider);
         // Auto-offline: download to device if enabled for this channel
         if (videoId != null && channelId != null) {
           final storageService = ref.read(storageServiceProvider);
@@ -84,8 +85,19 @@ final webSocketConnectionProvider = Provider<void>((ref) {
       case WebSocketEventType.previewReady:
         break; // Player screen listens directly via wsService.events
       case WebSocketEventType.newEpisode:
+        // New content landed server-side — refresh the home feed in place.
         ref.invalidate(newEpisodesProvider);
         ref.invalidate(recentlyAddedProvider);
+        ref.invalidate(homeFeedProvider);
+      case WebSocketEventType.progressUpdated:
+        // Cross-device watch-progress sync: another device moved the playhead,
+        // so resume positions and continue-watching ordering may have changed.
+        final videoId = event.data['video_id'] as String?;
+        if (videoId != null) {
+          ref.invalidate(videoDetailProvider(videoId));
+        }
+        ref.invalidate(continueWatchingProvider);
+        ref.invalidate(homeFeedProvider);
       case WebSocketEventType.recommendationReady:
         ref.read(discoverProvider.notifier).load();
       case WebSocketEventType.unknown:

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -13,36 +13,48 @@ import '../config/theme.dart';
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
+  Widget _buildFeed(HomeFeed feed) {
+    final allEmpty =
+        feed.continueWatching.isEmpty &&
+        feed.newEpisodes.isEmpty &&
+        feed.recentlyAdded.isEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        if (feed.continueWatching.isNotEmpty)
+          _buildRow(
+            title: 'Continue Watching',
+            items: feed.continueWatching,
+            showProgress: true,
+          ),
+        if (feed.newEpisodes.isNotEmpty)
+          _buildRow(title: 'New Episodes', items: feed.newEpisodes),
+        if (feed.recentlyAdded.isNotEmpty)
+          _buildRow(title: 'Recently Added', items: feed.recentlyAdded),
+        if (allEmpty) const _EmptyHomeState(),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
   Widget _buildRow({
     required String title,
-    required AsyncValue<List<FeedItem>> items,
-    required VoidCallback onRetry,
+    required List<FeedItem> items,
     bool showProgress = false,
   }) {
-    return items.when(
-      data: (list) {
-        if (list.isEmpty) return const SizedBox.shrink();
-        return ContentRow(
-          title: title,
-          children: list
-              .map(
-                (item) => VideoCard(
-                  video: item.video,
-                  channel: item.channel,
-                  showProgress: showProgress,
-                ),
-              )
-              .toList(),
-        );
-      },
-      loading: () =>
-          ContentRow(title: title, isLoading: true, children: const []),
-      error: (error, _) => ContentRow(
-        title: title,
-        errorText: '$error',
-        onRetry: onRetry,
-        children: const [],
-      ),
+    return ContentRow(
+      title: title,
+      children: items
+          .map(
+            (item) => VideoCard(
+              video: item.video,
+              channel: item.channel,
+              showProgress: showProgress,
+            ),
+          )
+          .toList(),
     );
   }
 
@@ -51,14 +63,9 @@ class HomeScreen extends ConsumerWidget {
     // Initialize WebSocket connection
     ref.watch(webSocketConnectionProvider);
 
-    final continueWatching = ref.watch(continueWatchingProvider);
-    final newEpisodes = ref.watch(newEpisodesProvider);
-    final recentlyAdded = ref.watch(recentlyAddedProvider);
-
-    final rows = [continueWatching, newEpisodes, recentlyAdded];
-    final allEmpty = rows.every(
-      (row) => row.hasValue && !row.hasError && (row.value?.isEmpty ?? false),
-    );
+    // The whole feed now arrives in a single request; rows are derived from it
+    // and the WebSocket service invalidates this provider for live updates.
+    final homeFeed = ref.watch(homeFeedProvider);
 
     Future<void> refresh() async {
       // Fire-and-forget: kick a server-side poll of all channels so new
@@ -66,14 +73,12 @@ class HomeScreen extends ConsumerWidget {
       unawaited(
         ref.read(apiServiceProvider).pollAllChannels().catchError((_) {}),
       );
+      // Reload the unified feed and keep the spinner up until it resolves.
+      final reload = ref.refresh(homeFeedProvider.future);
       try {
-        await Future.wait([
-          ref.refresh(continueWatchingProvider.future),
-          ref.refresh(newEpisodesProvider.future),
-          ref.refresh(recentlyAddedProvider.future),
-        ]);
+        await reload;
       } catch (_) {
-        // Each row renders its own inline error state.
+        // The inline error state renders instead.
       }
     }
 
@@ -100,31 +105,73 @@ class HomeScreen extends ConsumerWidget {
               backgroundColor: NullFeedTheme.backgroundColor,
             ),
             SliverToBoxAdapter(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SizedBox(height: 8),
-                  _buildRow(
-                    title: 'Continue Watching',
-                    items: continueWatching,
-                    onRetry: () => ref.invalidate(continueWatchingProvider),
-                    showProgress: true,
-                  ),
-                  _buildRow(
-                    title: 'New Episodes',
-                    items: newEpisodes,
-                    onRetry: () => ref.invalidate(newEpisodesProvider),
-                  ),
-                  _buildRow(
-                    title: 'Recently Added',
-                    items: recentlyAdded,
-                    onRetry: () => ref.invalidate(recentlyAddedProvider),
-                  ),
-                  if (allEmpty) const _EmptyHomeState(),
-                  const SizedBox(height: 24),
-                ],
+              child: homeFeed.when(
+                data: _buildFeed,
+                loading: () => const _HomeFeedSkeleton(),
+                error: (error, _) => _HomeFeedError(
+                  message: '$error',
+                  onRetry: () => ref.invalidate(homeFeedProvider),
+                ),
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shimmer placeholders for the three rows while the feed loads.
+class _HomeFeedSkeleton extends StatelessWidget {
+  const _HomeFeedSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(height: 8),
+        ContentRow(title: 'Continue Watching', isLoading: true, children: []),
+        ContentRow(title: 'New Episodes', isLoading: true, children: []),
+        ContentRow(title: 'Recently Added', isLoading: true, children: []),
+        SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+class _HomeFeedError extends StatelessWidget {
+  const _HomeFeedError({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 120, horizontal: 48),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 64,
+              color: NullFeedTheme.errorColor,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Could not load your feed',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton(onPressed: onRetry, child: const Text('Retry')),
           ],
         ),
       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -74,6 +74,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     ref.invalidate(channelDetailProvider);
     ref.invalidate(channelVideosProvider);
     ref.invalidate(videoDetailProvider);
+    ref.invalidate(homeFeedProvider);
     ref.invalidate(continueWatchingProvider);
     ref.invalidate(newEpisodesProvider);
     ref.invalidate(recentlyAddedProvider);

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -23,10 +23,17 @@ class ApiException implements Exception {
   final int? statusCode;
   final bool isConnectionError;
 
+  /// Machine-readable error code from the backend error envelope
+  /// (e.g. `unauthorized`, `not_found`, `conflict`, `validation_error`,
+  /// `rate_limited`). Null for connection failures and any legacy/plain
+  /// responses that only carry a `detail` string.
+  final String? code;
+
   const ApiException({
     required this.message,
     this.statusCode,
     this.isConnectionError = false,
+    this.code,
   });
 
   factory ApiException.fromDioException(DioException error) {
@@ -40,9 +47,15 @@ class ApiException implements Exception {
     };
 
     String? detail;
+    String? code;
     final data = error.response?.data;
-    if (data is Map && data['detail'] is String) {
-      detail = data['detail'] as String;
+    if (data is Map) {
+      if (data['detail'] is String) {
+        detail = data['detail'] as String;
+      }
+      if (data['code'] is String) {
+        code = data['code'] as String;
+      }
     }
 
     final message =
@@ -57,6 +70,7 @@ class ApiException implements Exception {
       message: message,
       statusCode: statusCode,
       isConnectionError: isConnectionError,
+      code: code,
     );
   }
 
@@ -390,6 +404,18 @@ class ApiService {
   }
 
   // Feed
+
+  /// Unified home feed: continue-watching, new-episodes and recently-added in
+  /// a single round-trip. Preferred over the three per-row endpoints below,
+  /// which remain for callers that need an individual row.
+  Future<HomeFeed> getHomeFeed({int limit = 20}) => _guard(() async {
+    final response = await _dio.get(
+      '$_baseUrl${AppConstants.feedHome}',
+      queryParameters: {'limit': limit},
+    );
+    return HomeFeed.fromJson(response.data as Map<String, dynamic>);
+  });
+
   Future<List<FeedItem>> getContinueWatching() => _guard(() async {
     final response = await _dio.get(
       '$_baseUrl${AppConstants.feedContinueWatching}',

--- a/lib/services/websocket_service.dart
+++ b/lib/services/websocket_service.dart
@@ -8,6 +8,7 @@ enum WebSocketEventType {
   downloadComplete,
   previewReady,
   newEpisode,
+  progressUpdated,
   recommendationReady,
   unknown,
 }
@@ -26,6 +27,7 @@ class WebSocketEvent {
       'download_complete' => WebSocketEventType.downloadComplete,
       'preview_ready' => WebSocketEventType.previewReady,
       'new_episode' => WebSocketEventType.newEpisode,
+      'progress_updated' => WebSocketEventType.progressUpdated,
       'recommendation_ready' => WebSocketEventType.recommendationReady,
       _ => WebSocketEventType.unknown,
     };

--- a/test/unit/api_exception_test.dart
+++ b/test/unit/api_exception_test.dart
@@ -72,6 +72,35 @@ void main() {
       expect(exception.message, 'Request failed (400)');
     });
 
+    test('parses the machine-readable code alongside the detail', () {
+      final exception = ApiException.fromDioException(
+        _dioError(
+          statusCode: 409,
+          data: {'detail': 'Already subscribed', 'code': 'conflict'},
+        ),
+      );
+
+      expect(exception.message, 'Already subscribed');
+      expect(exception.code, 'conflict');
+      expect(exception.statusCode, 409);
+    });
+
+    test('leaves code null when the envelope omits it', () {
+      final exception = ApiException.fromDioException(
+        _dioError(statusCode: 500, data: {'detail': 'boom'}),
+      );
+
+      expect(exception.code, isNull);
+    });
+
+    test('ignores a non-string code', () {
+      final exception = ApiException.fromDioException(
+        _dioError(statusCode: 400, data: {'detail': 'bad', 'code': 42}),
+      );
+
+      expect(exception.code, isNull);
+    });
+
     test('falls back to a generic message when there is no response', () {
       final exception = ApiException.fromDioException(
         _dioError(type: DioExceptionType.unknown),

--- a/test/unit/models_test.dart
+++ b/test/unit/models_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nullfeed/models/channel.dart';
+import 'package:nullfeed/models/feed.dart';
 import 'package:nullfeed/models/json_converters.dart';
 import 'package:nullfeed/models/user.dart';
 import 'package:nullfeed/models/video.dart';
@@ -201,6 +202,44 @@ void main() {
 
       expect(video.uploadedAt, isNull);
       expect(video.status, VideoStatus.cataloged);
+    });
+  });
+
+  group('HomeFeed', () {
+    Map<String, dynamic> feedItem(String videoId) => {
+      'channel': {
+        'id': 'c1',
+        'youtube_channel_id': 'UCabc',
+        'name': 'Some Channel',
+        'slug': 'some-channel',
+      },
+      'video': {
+        'id': videoId,
+        'youtube_video_id': 'yt-$videoId',
+        'channel_id': 'c1',
+        'title': 'Video $videoId',
+      },
+    };
+
+    test('parses the three rows from the unified payload', () {
+      final feed = HomeFeed.fromJson({
+        'continue_watching': [feedItem('v1')],
+        'new_episodes': [feedItem('v2'), feedItem('v3')],
+        'recently_added': [feedItem('v4')],
+      });
+
+      expect(feed.continueWatching.single.video.id, 'v1');
+      expect(feed.newEpisodes, hasLength(2));
+      expect(feed.recentlyAdded.single.video.id, 'v4');
+      expect(feed.continueWatching.single.channel.name, 'Some Channel');
+    });
+
+    test('defaults each row to empty when a key is absent', () {
+      final feed = HomeFeed.fromJson(const {});
+
+      expect(feed.continueWatching, isEmpty);
+      expect(feed.newEpisodes, isEmpty);
+      expect(feed.recentlyAdded, isEmpty);
     });
   });
 

--- a/test/unit/websocket_service_test.dart
+++ b/test/unit/websocket_service_test.dart
@@ -78,6 +78,7 @@ void main() {
         'download_complete': WebSocketEventType.downloadComplete,
         'preview_ready': WebSocketEventType.previewReady,
         'new_episode': WebSocketEventType.newEpisode,
+        'progress_updated': WebSocketEventType.progressUpdated,
         'recommendation_ready': WebSocketEventType.recommendationReady,
         'something_else': WebSocketEventType.unknown,
       };


### PR DESCRIPTION
Flutter consumer for the backend wave-2 contract (roadmap NEXT tier).

## Unified home feed (one request)
`homeFeedProvider` (previously unused, and implemented as three chained requests) now issues a single `GET /api/feed/home` via the new `ApiService.getHomeFeed()`. The home screen watches only `homeFeedProvider`; loading (shimmer rows), error (message + Retry), and empty states are all preserved (now consolidated to screen-level since it's one request). Per-row providers/endpoints are kept for other callers.

## Error code
`ApiException` gains a `code` field parsed from the backend `{detail, code}` envelope, alongside the existing `detail` string parsing — fully backward compatible (`code` is null for connection errors / legacy responses). Surfaced as a public field for the ~15 catch sites; existing message-based handling unchanged.

## Live feed refresh
Added `WebSocketEventType.progressUpdated`. `new_episode` and `download_complete` now invalidate `homeFeedProvider`; `progress_updated` invalidates `homeFeedProvider`, `continueWatchingProvider`, and the relevant `videoDetailProvider` (cross-device resume). Riverpod's `skipLoadingOnRefresh` keeps content visible during the in-place reload (no skeleton flash). `invalidateFeedProviders` also feeds the unified provider.

Tests: +3 (HomeFeed parsing, `code` parsed/ignored-when-absent, `progress_updated` mapping).

## Verification
- `dart format --set-exit-if-changed .` — clean
- `flutter analyze --fatal-infos --fatal-warnings` — No issues found
- `flutter test` — 77 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY