### PR TITLE
feat: iOS polish — touch feedback, player speed/buffering, remove dead TV scaffolding

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -63,6 +63,11 @@ class AppConstants {
   static const int skipForwardSeconds = 10;
   static const int skipBackwardSeconds = 10;
 
+  /// How long to wait for a server-side preview/HQ render before giving up and
+  /// showing a graceful "taking longer than expected" message instead of an
+  /// indefinite spinner.
+  static const int previewMaxWaitSeconds = 180;
+
   // UI
   static const double cardAspectRatio = 16 / 9;
   static const double channelCardWidth = 280.0;

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -11,6 +11,7 @@ import '../services/api_service.dart';
 import '../services/offline_service.dart';
 import '../services/websocket_service.dart';
 import '../config/constants.dart';
+import '../config/theme.dart';
 import '../widgets/progress_bar.dart';
 
 class VideoPlayerScreen extends ConsumerStatefulWidget {
@@ -27,6 +28,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   Timer? _hideControlsTimer;
   Timer? _previewTimeout;
   Timer? _previewPollTimer;
+  Timer? _previewMaxWait;
   bool _showControls = true;
   bool _isInitialized = false;
   bool _isPreviewMode = false;
@@ -229,6 +231,23 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       _startPreviewPolling();
     });
 
+    // Hard cap on the wait. If the preview never arrives, stop spinning forever
+    // and surface a graceful message instead of leaving the user on a black
+    // screen indefinitely.
+    _previewMaxWait?.cancel();
+    _previewMaxWait = Timer(
+      const Duration(seconds: AppConstants.previewMaxWaitSeconds),
+      () {
+        if (!mounted || _isInitialized) return;
+        _stopWaiting();
+        setState(() {
+          _error =
+              'This video is taking longer than expected to prepare. '
+              'Please try again in a moment.';
+        });
+      },
+    );
+
     _wsSubscription = wsService.events.listen((event) {
       if (event.type == WebSocketEventType.previewReady &&
           event.data['video_id'] == widget.videoId) {
@@ -280,6 +299,8 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _previewTimeout = null;
     _previewPollTimer?.cancel();
     _previewPollTimer = null;
+    _previewMaxWait?.cancel();
+    _previewMaxWait = null;
     _wsSubscription?.cancel();
     _wsSubscription = null;
   }
@@ -304,8 +325,10 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       return;
     }
 
-    // Capture current position
+    // Capture current position and the user's chosen speed so the upgrade is
+    // seamless.
     final currentPosition = _controller!.value.position;
+    final currentSpeed = _controller!.value.playbackSpeed;
 
     try {
       final streamUrl = _api.getVideoStreamUrl(widget.videoId);
@@ -314,6 +337,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       );
       await hqController.initialize();
       await hqController.seekTo(currentPosition);
+      await hqController.setPlaybackSpeed(currentSpeed);
       await hqController.play();
 
       if (!mounted) {
@@ -451,6 +475,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _hideControlsTimer?.cancel();
     _previewTimeout?.cancel();
     _previewPollTimer?.cancel();
+    _previewMaxWait?.cancel();
     // Save final position (fire-and-forget; a failed save must never throw
     // out of dispose). Skipped when _navigateBack already fired the save on
     // the way out, so teardown sends exactly one /progress PUT.
@@ -537,7 +562,28 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
                   ),
                 )
               else
-                const Center(child: CircularProgressIndicator()),
+                const Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      CircularProgressIndicator(),
+                      SizedBox(height: 16),
+                      Text(
+                        'Preparing your video…',
+                        style: TextStyle(color: Colors.white70, fontSize: 14),
+                      ),
+                    ],
+                  ),
+                ),
+
+              // Buffering spinner while the player stalls mid-playback.
+              if (_isInitialized && _controller != null)
+                ValueListenableBuilder(
+                  valueListenable: _controller!,
+                  builder: (_, value, __) => value.isBuffering
+                      ? const Center(child: CircularProgressIndicator())
+                      : const SizedBox.shrink(),
+                ),
 
               // Back button while waiting for the player to come up — the
               // controls overlay only exists once playback started.
@@ -638,6 +684,11 @@ class _ControlsOverlay extends StatelessWidget {
                   IconButton(
                     icon: const Icon(Icons.arrow_back, color: Colors.white),
                     onPressed: onBack,
+                  ),
+                  const Spacer(),
+                  _SpeedButton(
+                    controller: controller,
+                    onInteraction: onInteraction,
                   ),
                 ],
               ),
@@ -757,5 +808,80 @@ class _ControlsOverlay extends StatelessWidget {
       return '$hours:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
     }
     return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+}
+
+/// Playback-speed picker shown in the controls overlay. Reflects the
+/// controller's current speed live and lets the viewer pick 0.5x–2x.
+class _SpeedButton extends StatelessWidget {
+  final VideoPlayerController controller;
+  final VoidCallback onInteraction;
+
+  const _SpeedButton({required this.controller, required this.onInteraction});
+
+  static const List<double> _speeds = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
+
+  String _label(double speed) {
+    final value = speed == speed.roundToDouble()
+        ? speed.toStringAsFixed(0)
+        : speed.toString();
+    return '${value}x';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: controller,
+      builder: (_, value, __) => PopupMenuButton<double>(
+        tooltip: 'Playback speed',
+        initialValue: value.playbackSpeed,
+        color: NullFeedTheme.surfaceColor,
+        onSelected: (speed) {
+          controller.setPlaybackSpeed(speed);
+          onInteraction();
+        },
+        itemBuilder: (_) => [
+          for (final speed in _speeds)
+            PopupMenuItem<double>(
+              value: speed,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.check,
+                    size: 18,
+                    color: value.playbackSpeed == speed
+                        ? NullFeedTheme.primaryColor
+                        : Colors.transparent,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    _label(speed),
+                    style: const TextStyle(color: NullFeedTheme.textPrimary),
+                  ),
+                ],
+              ),
+            ),
+        ],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.speed, color: Colors.white, size: 20),
+              const SizedBox(width: 4),
+              Text(
+                _label(value.playbackSpeed),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/adaptive_layout.dart
+++ b/lib/widgets/adaptive_layout.dart
@@ -17,10 +17,6 @@ class AdaptiveLayout extends StatelessWidget {
     return DeviceType.phone;
   }
 
-  /// The Flutter app is iOS-only (the native tvOS app covers Apple TV).
-  /// Kept so existing call sites don't need churn.
-  static bool isTv(BuildContext context) => false;
-
   static bool isTablet(BuildContext context) =>
       getDeviceType(context) == DeviceType.tablet;
 

--- a/lib/widgets/channel_card.dart
+++ b/lib/widgets/channel_card.dart
@@ -23,164 +23,134 @@ class ChannelCard extends StatefulWidget {
 }
 
 class _ChannelCardState extends State<ChannelCard> {
-  bool _isHovered = false;
-  bool _isFocused = false;
+  bool _isPressed = false;
 
-  bool get _isHighlighted => _isHovered || _isFocused;
+  void _handleTap() {
+    final onTap = widget.onTap;
+    if (onTap == null) return;
+    HapticFeedback.selectionClick();
+    onTap();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Focus(
-      onFocusChange: (focused) => setState(() => _isFocused = focused),
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.select ||
-                event.logicalKey == LogicalKeyboardKey.enter)) {
-          widget.onTap?.call();
-          return KeyEventResult.handled;
-        }
-        return KeyEventResult.ignored;
-      },
-      child: MouseRegion(
-        onEnter: (_) => setState(() => _isHovered = true),
-        onExit: (_) => setState(() => _isHovered = false),
-        child: GestureDetector(
-          onTap: widget.onTap,
+    return AnimatedScale(
+      scale: _isPressed ? 0.97 : 1.0,
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOut,
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: widget.onTap == null ? null : _handleTap,
           onLongPress: widget.onMenu,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            transform: _isHighlighted
-                ? (Matrix4.identity()..scaleByDouble(1.03, 1.03, 1.0, 1.0))
-                : Matrix4.identity(),
-            transformAlignment: Alignment.center,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border: _isFocused
-                  ? Border.all(color: NullFeedTheme.primaryColor, width: 3)
-                  : null,
-              boxShadow: _isFocused
-                  ? [
-                      BoxShadow(
-                        color: NullFeedTheme.primaryColor.withValues(
+          onTapDown: (_) => setState(() => _isPressed = true),
+          onTapUp: (_) => setState(() => _isPressed = false),
+          onTapCancel: () => setState(() => _isPressed = false),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              // Banner image
+              if (widget.channel.bannerUrl != null)
+                CachedNetworkImage(
+                  imageUrl: widget.channel.bannerUrl!,
+                  fit: BoxFit.cover,
+                  errorWidget: (_, __, ___) =>
+                      Container(color: NullFeedTheme.cardColor),
+                  placeholder: (_, __) =>
+                      Container(color: NullFeedTheme.cardColor),
+                )
+              else
+                Container(
+                  color: NullFeedTheme.cardColor,
+                  child: Center(
+                    child: Icon(
+                      Icons.subscriptions,
+                      size: 40,
+                      color: NullFeedTheme.primaryColor.withValues(alpha: 0.3),
+                    ),
+                  ),
+                ),
+
+              // Gradient overlay
+              Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.transparent,
+                      Colors.black.withValues(alpha: 0.85),
+                    ],
+                    stops: const [0.3, 1.0],
+                  ),
+                ),
+              ),
+
+              // Actions menu button
+              if (widget.onMenu != null)
+                Positioned(
+                  top: 4,
+                  right: 4,
+                  child: IconButton(
+                    icon: const Icon(Icons.more_vert, size: 20),
+                    color: Colors.white70,
+                    style: IconButton.styleFrom(
+                      backgroundColor: Colors.black.withValues(alpha: 0.4),
+                    ),
+                    visualDensity: VisualDensity.compact,
+                    onPressed: widget.onMenu,
+                    tooltip: 'Channel actions',
+                  ),
+                ),
+
+              // Channel info
+              Positioned(
+                left: 12,
+                right: 12,
+                bottom: 12,
+                child: Row(
+                  children: [
+                    if (widget.channel.avatarUrl != null)
+                      CircleAvatar(
+                        radius: 18,
+                        backgroundImage: CachedNetworkImageProvider(
+                          widget.channel.avatarUrl!,
+                        ),
+                      )
+                    else
+                      CircleAvatar(
+                        radius: 18,
+                        backgroundColor: NullFeedTheme.primaryColor.withValues(
                           alpha: 0.3,
                         ),
-                        blurRadius: 16,
-                        spreadRadius: 2,
-                      ),
-                    ]
-                  : null,
-            ),
-            child: Card(
-              clipBehavior: Clip.antiAlias,
-              color: _isHighlighted ? NullFeedTheme.cardHoverColor : null,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  // Banner image
-                  if (widget.channel.bannerUrl != null)
-                    CachedNetworkImage(
-                      imageUrl: widget.channel.bannerUrl!,
-                      fit: BoxFit.cover,
-                      errorWidget: (_, __, ___) =>
-                          Container(color: NullFeedTheme.cardColor),
-                      placeholder: (_, __) =>
-                          Container(color: NullFeedTheme.cardColor),
-                    )
-                  else
-                    Container(
-                      color: NullFeedTheme.cardColor,
-                      child: Center(
-                        child: Icon(
-                          Icons.subscriptions,
-                          size: 40,
-                          color: NullFeedTheme.primaryColor.withValues(
-                            alpha: 0.3,
+                        child: Text(
+                          widget.channel.name.isNotEmpty
+                              ? widget.channel.name[0].toUpperCase()
+                              : '?',
+                          style: const TextStyle(
+                            color: NullFeedTheme.primaryColor,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
                           ),
                         ),
                       ),
-                    ),
-
-                  // Gradient overlay
-                  Container(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.transparent,
-                          Colors.black.withValues(alpha: 0.85),
-                        ],
-                        stops: const [0.3, 1.0],
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        widget.channel.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
                     ),
-                  ),
-
-                  // Actions menu button
-                  if (widget.onMenu != null)
-                    Positioned(
-                      top: 4,
-                      right: 4,
-                      child: IconButton(
-                        icon: const Icon(Icons.more_vert, size: 20),
-                        color: Colors.white70,
-                        style: IconButton.styleFrom(
-                          backgroundColor: Colors.black.withValues(alpha: 0.4),
-                        ),
-                        visualDensity: VisualDensity.compact,
-                        onPressed: widget.onMenu,
-                        tooltip: 'Channel actions',
-                      ),
-                    ),
-
-                  // Channel info
-                  Positioned(
-                    left: 12,
-                    right: 12,
-                    bottom: 12,
-                    child: Row(
-                      children: [
-                        if (widget.channel.avatarUrl != null)
-                          CircleAvatar(
-                            radius: 18,
-                            backgroundImage: CachedNetworkImageProvider(
-                              widget.channel.avatarUrl!,
-                            ),
-                          )
-                        else
-                          CircleAvatar(
-                            radius: 18,
-                            backgroundColor: NullFeedTheme.primaryColor
-                                .withValues(alpha: 0.3),
-                            child: Text(
-                              widget.channel.name.isNotEmpty
-                                  ? widget.channel.name[0].toUpperCase()
-                                  : '?',
-                              style: const TextStyle(
-                                color: NullFeedTheme.primaryColor,
-                                fontWeight: FontWeight.bold,
-                                fontSize: 14,
-                              ),
-                            ),
-                          ),
-                        const SizedBox(width: 10),
-                        Expanded(
-                          child: Text(
-                            widget.channel.name,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 15,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
+            ],
           ),
         ),
       ),

--- a/lib/widgets/video_card.dart
+++ b/lib/widgets/video_card.dart
@@ -28,10 +28,7 @@ class VideoCard extends ConsumerStatefulWidget {
 }
 
 class _VideoCardState extends ConsumerState<VideoCard> {
-  bool _isHovered = false;
-  bool _isFocused = false;
-
-  bool get _isHighlighted => _isHovered || _isFocused;
+  bool _isPressed = false;
 
   String? get _thumbnailUrl {
     if (widget.video.youtubeVideoId.isNotEmpty) {
@@ -41,6 +38,7 @@ class _VideoCardState extends ConsumerState<VideoCard> {
   }
 
   Future<void> _onActivate() async {
+    HapticFeedback.selectionClick();
     // Every home-feed card plays its video on tap; channel navigation lives
     // on the channel sub-row below (see [_openChannel]).
     await context.push('/player/${widget.video.id}');
@@ -52,6 +50,7 @@ class _VideoCardState extends ConsumerState<VideoCard> {
   void _openChannel() {
     final channel = widget.channel;
     if (channel == null) return;
+    HapticFeedback.selectionClick();
     context.push('/channel/${channel.id}');
   }
 
@@ -59,208 +58,181 @@ class _VideoCardState extends ConsumerState<VideoCard> {
   Widget build(BuildContext context) {
     const cardWidth = AppConstants.videoCardWidth;
 
-    return Focus(
-      onFocusChange: (focused) => setState(() => _isFocused = focused),
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.select ||
-                event.logicalKey == LogicalKeyboardKey.enter)) {
-          _onActivate();
-          return KeyEventResult.handled;
-        }
-        return KeyEventResult.ignored;
-      },
-      child: MouseRegion(
-        onEnter: (_) => setState(() => _isHovered = true),
-        onExit: (_) => setState(() => _isHovered = false),
-        child: GestureDetector(
-          onTap: _onActivate,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            width: cardWidth,
-            transform: _isHighlighted
-                ? (Matrix4.identity()..scaleByDouble(1.05, 1.05, 1.0, 1.0))
-                : Matrix4.identity(),
-            transformAlignment: Alignment.center,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border: _isFocused
-                  ? Border.all(color: NullFeedTheme.primaryColor, width: 3)
-                  : null,
-              boxShadow: _isFocused
-                  ? [
-                      BoxShadow(
-                        color: NullFeedTheme.primaryColor.withValues(
-                          alpha: 0.3,
-                        ),
-                        blurRadius: 16,
-                        spreadRadius: 2,
-                      ),
-                    ]
-                  : null,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Thumbnail
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: AspectRatio(
-                    aspectRatio: AppConstants.cardAspectRatio,
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: [
-                        if (_thumbnailUrl != null)
-                          CachedNetworkImage(
-                            imageUrl: _thumbnailUrl!,
-                            fit: BoxFit.cover,
-                            errorWidget: (_, __, ___) => Container(
-                              color: NullFeedTheme.cardColor,
-                              child: const Icon(
-                                Icons.play_circle_outline,
-                                color: NullFeedTheme.textMuted,
-                                size: 40,
-                              ),
-                            ),
-                            placeholder: (_, __) =>
-                                Container(color: NullFeedTheme.cardColor),
-                          )
-                        else
-                          Container(
-                            color: NullFeedTheme.cardColor,
-                            child: const Icon(
-                              Icons.play_circle_outline,
-                              color: NullFeedTheme.textMuted,
-                              size: 40,
-                            ),
-                          ),
-
-                        // Duration badge
-                        if (widget.video.durationSeconds > 0)
-                          Positioned(
-                            right: 6,
-                            bottom: 6,
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 6,
-                                vertical: 2,
-                              ),
-                              decoration: BoxDecoration(
-                                color: Colors.black.withValues(alpha: 0.8),
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                              child: Text(
-                                widget.video.formattedDuration,
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w500,
+    return AnimatedScale(
+      scale: _isPressed ? 0.97 : 1.0,
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOut,
+      child: SizedBox(
+        width: cardWidth,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Thumbnail + progress + title are one tap target that plays.
+            Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: _onActivate,
+                onTapDown: (_) => setState(() => _isPressed = true),
+                onTapUp: (_) => setState(() => _isPressed = false),
+                onTapCancel: () => setState(() => _isPressed = false),
+                borderRadius: BorderRadius.circular(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Thumbnail
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: AspectRatio(
+                        aspectRatio: AppConstants.cardAspectRatio,
+                        child: Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            if (_thumbnailUrl != null)
+                              CachedNetworkImage(
+                                imageUrl: _thumbnailUrl!,
+                                fit: BoxFit.cover,
+                                errorWidget: (_, __, ___) => Container(
+                                  color: NullFeedTheme.cardColor,
+                                  child: const Icon(
+                                    Icons.play_circle_outline,
+                                    color: NullFeedTheme.textMuted,
+                                    size: 40,
+                                  ),
+                                ),
+                                placeholder: (_, __) =>
+                                    Container(color: NullFeedTheme.cardColor),
+                              )
+                            else
+                              Container(
+                                color: NullFeedTheme.cardColor,
+                                child: const Icon(
+                                  Icons.play_circle_outline,
+                                  color: NullFeedTheme.textMuted,
+                                  size: 40,
                                 ),
                               ),
-                            ),
-                          ),
 
-                        // Offline badge
-                        if (ref.watch(offlineStatusProvider(widget.video.id)) ==
-                            'complete')
-                          Positioned(
-                            left: 6,
-                            bottom: 6,
-                            child: Container(
-                              padding: const EdgeInsets.all(4),
-                              decoration: BoxDecoration(
-                                color: Colors.black.withValues(alpha: 0.7),
-                                borderRadius: BorderRadius.circular(4),
+                            // Duration badge
+                            if (widget.video.durationSeconds > 0)
+                              Positioned(
+                                right: 6,
+                                bottom: 6,
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: Colors.black.withValues(alpha: 0.8),
+                                    borderRadius: BorderRadius.circular(4),
+                                  ),
+                                  child: Text(
+                                    widget.video.formattedDuration,
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                ),
                               ),
-                              child: const Icon(
-                                Icons.offline_pin,
-                                color: NullFeedTheme.successColor,
-                                size: 16,
-                              ),
-                            ),
-                          ),
 
-                        // Play icon overlay on highlight
-                        if (_isHighlighted)
-                          Container(
-                            color: Colors.black38,
-                            child: const Center(
-                              child: Icon(
-                                Icons.play_arrow,
-                                color: Colors.white,
-                                size: 48,
+                            // Offline badge
+                            if (ref.watch(
+                                  offlineStatusProvider(widget.video.id),
+                                ) ==
+                                'complete')
+                              Positioned(
+                                left: 6,
+                                bottom: 6,
+                                child: Container(
+                                  padding: const EdgeInsets.all(4),
+                                  decoration: BoxDecoration(
+                                    color: Colors.black.withValues(alpha: 0.7),
+                                    borderRadius: BorderRadius.circular(4),
+                                  ),
+                                  child: const Icon(
+                                    Icons.offline_pin,
+                                    color: NullFeedTheme.successColor,
+                                    size: 16,
+                                  ),
+                                ),
                               ),
+                          ],
+                        ),
+                      ),
+                    ),
+
+                    // Progress bar
+                    if (widget.showProgress && widget.video.watchProgress > 0)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: NullFeedProgressBar(
+                          progress: widget.video.watchProgress,
+                          height: 3,
+                        ),
+                      ),
+
+                    // Title
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(
+                        widget.video.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: NullFeedTheme.textPrimary,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // Channel sub-row → open the channel.
+            if (widget.channel != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Material(
+                  type: MaterialType.transparency,
+                  child: InkWell(
+                    onTap: _openChannel,
+                    borderRadius: BorderRadius.circular(8),
+                    child: Row(
+                      children: [
+                        if (widget.channel!.avatarUrl != null)
+                          Padding(
+                            padding: const EdgeInsets.only(right: 6),
+                            child: CircleAvatar(
+                              radius: 10,
+                              backgroundImage: CachedNetworkImageProvider(
+                                widget.channel!.avatarUrl!,
+                              ),
+                              backgroundColor: NullFeedTheme.cardColor,
                             ),
                           ),
+                        Expanded(
+                          child: Text(
+                            widget.channel!.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: NullFeedTheme.textMuted,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                   ),
                 ),
-
-                // Progress bar
-                if (widget.showProgress && widget.video.watchProgress > 0)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 2),
-                    child: NullFeedProgressBar(
-                      progress: widget.video.watchProgress,
-                      height: 3,
-                    ),
-                  ),
-
-                // Title & channel
-                Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: Text(
-                    widget.video.title,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: _isHighlighted
-                          ? NullFeedTheme.textPrimary
-                          : NullFeedTheme.textSecondary,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-                if (widget.channel != null)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: GestureDetector(
-                      onTap: _openChannel,
-                      behavior: HitTestBehavior.opaque,
-                      child: Row(
-                        children: [
-                          if (widget.channel!.avatarUrl != null)
-                            Padding(
-                              padding: const EdgeInsets.only(right: 6),
-                              child: CircleAvatar(
-                                radius: 10,
-                                backgroundImage: CachedNetworkImageProvider(
-                                  widget.channel!.avatarUrl!,
-                                ),
-                                backgroundColor: NullFeedTheme.cardColor,
-                              ),
-                            ),
-                          Expanded(
-                            child: Text(
-                              widget.channel!.name,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
-                                color: NullFeedTheme.textMuted,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/widgets/video_list_tile.dart
+++ b/lib/widgets/video_list_tile.dart
@@ -34,7 +34,12 @@ class VideoListTile extends ConsumerStatefulWidget {
 }
 
 class _VideoListTileState extends ConsumerState<VideoListTile> {
-  bool _isFocused = false;
+  bool _isPressed = false;
+
+  void _handleTap() {
+    HapticFeedback.selectionClick();
+    widget.onTap?.call();
+  }
 
   String? get _thumbnailUrl {
     if (widget.video.youtubeVideoId.isNotEmpty) {
@@ -159,164 +164,152 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
   Widget build(BuildContext context) {
     final isTappable = widget.onTap != null;
 
-    return Focus(
-      onFocusChange: (focused) => setState(() => _isFocused = focused),
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.select ||
-                event.logicalKey == LogicalKeyboardKey.enter)) {
-          if (isTappable) {
-            widget.onTap?.call();
-          }
-          return KeyEventResult.handled;
-        }
-        return KeyEventResult.ignored;
-      },
-      child: Opacity(
-        opacity: isTappable || widget.video.isPlayable ? 1.0 : 0.7,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          decoration: BoxDecoration(
-            color: _isFocused
-                ? NullFeedTheme.primaryColor.withValues(alpha: 0.15)
-                : Colors.transparent,
-            borderRadius: BorderRadius.circular(8),
-            border: _isFocused
-                ? Border.all(color: NullFeedTheme.primaryColor, width: 2)
-                : null,
-          ),
-          child: InkWell(
-            onTap: isTappable ? widget.onTap : null,
-            onLongPress: widget.onMenu,
-            borderRadius: BorderRadius.circular(8),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Row(
-                children: [
-                  // Thumbnail
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(6),
-                    child: SizedBox(
-                      width: 160,
-                      height: 90,
-                      child: Stack(
-                        fit: StackFit.expand,
-                        children: [
-                          if (_thumbnailUrl != null)
-                            CachedNetworkImage(
-                              imageUrl: _thumbnailUrl!,
-                              fit: BoxFit.cover,
-                              errorWidget: (_, __, ___) => Container(
-                                color: NullFeedTheme.cardColor,
-                                child: const Icon(
-                                  Icons.play_circle_outline,
-                                  color: NullFeedTheme.textMuted,
-                                ),
-                              ),
-                            )
-                          else
-                            Container(
+    return Opacity(
+      opacity: isTappable || widget.video.isPlayable ? 1.0 : 0.7,
+      child: AnimatedScale(
+        scale: _isPressed ? 0.98 : 1.0,
+        duration: const Duration(milliseconds: 120),
+        curve: Curves.easeOut,
+        child: InkWell(
+          onTap: isTappable ? _handleTap : null,
+          onLongPress: widget.onMenu,
+          onTapDown: isTappable
+              ? (_) => setState(() => _isPressed = true)
+              : null,
+          onTapUp: isTappable
+              ? (_) => setState(() => _isPressed = false)
+              : null,
+          onTapCancel: isTappable
+              ? () => setState(() => _isPressed = false)
+              : null,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                // Thumbnail
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(6),
+                  child: SizedBox(
+                    width: 160,
+                    height: 90,
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        if (_thumbnailUrl != null)
+                          CachedNetworkImage(
+                            imageUrl: _thumbnailUrl!,
+                            fit: BoxFit.cover,
+                            errorWidget: (_, __, ___) => Container(
                               color: NullFeedTheme.cardColor,
                               child: const Icon(
                                 Icons.play_circle_outline,
                                 color: NullFeedTheme.textMuted,
                               ),
                             ),
-                          // Duration
-                          if (widget.video.durationSeconds > 0)
-                            Positioned(
-                              right: 4,
-                              bottom: 4,
-                              child: Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 4,
-                                  vertical: 1,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: Colors.black.withValues(alpha: 0.8),
-                                  borderRadius: BorderRadius.circular(3),
-                                ),
-                                child: Text(
-                                  widget.video.formattedDuration,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.w500,
-                                  ),
-                                ),
-                              ),
+                          )
+                        else
+                          Container(
+                            color: NullFeedTheme.cardColor,
+                            child: const Icon(
+                              Icons.play_circle_outline,
+                              color: NullFeedTheme.textMuted,
                             ),
-                          // Watch progress bar
-                          if (widget.video.watchProgress > 0)
-                            Positioned(
-                              left: 0,
-                              right: 0,
-                              bottom: 0,
-                              child: NullFeedProgressBar(
-                                progress: widget.video.watchProgress,
-                                height: 3,
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  // Video info
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          widget.video.title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: NullFeedTheme.textPrimary,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
                           ),
-                        ),
-                        const SizedBox(height: 4),
-                        Row(
-                          children: [
-                            if (widget.video.uploadedAt != null)
-                              Text(
-                                DateFormat.yMMMd().format(
-                                  widget.video.uploadedAt!,
-                                ),
+                        // Duration
+                        if (widget.video.durationSeconds > 0)
+                          Positioned(
+                            right: 4,
+                            bottom: 4,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 4,
+                                vertical: 1,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.black.withValues(alpha: 0.8),
+                                borderRadius: BorderRadius.circular(3),
+                              ),
+                              child: Text(
+                                widget.video.formattedDuration,
                                 style: const TextStyle(
-                                  color: NullFeedTheme.textMuted,
-                                  fontSize: 12,
+                                  color: Colors.white,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w500,
                                 ),
                               ),
-                            if (widget.video.isWatched) ...[
-                              const SizedBox(width: 8),
-                              const Icon(
-                                Icons.check_circle,
-                                size: 14,
-                                color: NullFeedTheme.successColor,
-                              ),
-                            ],
-                          ],
-                        ),
+                            ),
+                          ),
+                        // Watch progress bar
+                        if (widget.video.watchProgress > 0)
+                          Positioned(
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+                            child: NullFeedProgressBar(
+                              progress: widget.video.watchProgress,
+                              height: 3,
+                            ),
+                          ),
                       ],
                     ),
                   ),
-                  // Status-aware trailing widget
-                  _buildTrailingWidget(),
-                  if (widget.onMenu != null)
-                    IconButton(
-                      icon: const Icon(
-                        Icons.more_vert,
-                        color: NullFeedTheme.textMuted,
+                ),
+                const SizedBox(width: 12),
+                // Video info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.video.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: NullFeedTheme.textPrimary,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                        ),
                       ),
-                      visualDensity: VisualDensity.compact,
-                      onPressed: widget.onMenu,
-                      tooltip: 'More actions',
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          if (widget.video.uploadedAt != null)
+                            Text(
+                              DateFormat.yMMMd().format(
+                                widget.video.uploadedAt!,
+                              ),
+                              style: const TextStyle(
+                                color: NullFeedTheme.textMuted,
+                                fontSize: 12,
+                              ),
+                            ),
+                          if (widget.video.isWatched) ...[
+                            const SizedBox(width: 8),
+                            const Icon(
+                              Icons.check_circle,
+                              size: 14,
+                              color: NullFeedTheme.successColor,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                // Status-aware trailing widget
+                _buildTrailingWidget(),
+                if (widget.onMenu != null)
+                  IconButton(
+                    icon: const Icon(
+                      Icons.more_vert,
+                      color: NullFeedTheme.textMuted,
                     ),
-                ],
-              ),
+                    visualDensity: VisualDensity.compact,
+                    onPressed: widget.onMenu,
+                    tooltip: 'More actions',
+                  ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
iOS interaction/visual polish (roadmap LATER tier, #19).

## Remove dead TV/desktop scaffolding
Cards carried `Focus`/`onKeyEvent`/`MouseRegion` code gated on `AdaptiveLayout.isTv()`, which is hardwired `false` on this iOS-only app. Stripped it (and the now-dead `isTv()`, which had zero references) from `video_card`, `channel_card`, `video_list_tile` — removing focus/hover-only scale, borders, glows, and the misleading hover play overlay. Legitimate playability dimming is kept.

## Readable titles
`video_card` titles rendered permanently in the muted secondary color on touch — now the primary text color.

## Touch feedback
InkWell ripple + a subtle `AnimatedScale` on press + `HapticFeedback.selectionClick()` on all three cards. The channel sub-row is its own Material/InkWell so it gives independent feedback and never triggers play.

## Player affordances
- **Playback-speed menu** (0.5×–2×) reflecting live speed, preserved across the preview→HQ swap.
- **Buffering overlay** spinner driven by the controller's buffering state.
- **Bounded preview wait**: the indefinite spinner is now "Preparing your video…", with a 180s (`previewMaxWaitSeconds`) cap that surfaces a graceful retry message instead of hanging forever.

## Verification
- `dart format` — clean · `flutter analyze --fatal-infos --fatal-warnings` — No issues · `flutter test` — 77 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY