### PR TITLE
feat: library search for videos and channels

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -11,6 +11,7 @@ import '../screens/downloads_screen.dart';
 import '../screens/settings_screen.dart';
 import '../screens/channel_detail_screen.dart';
 import '../screens/video_player_screen.dart';
+import '../screens/search_screen.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
@@ -98,6 +99,11 @@ final routerProvider = Provider<GoRouter>((ref) {
         parentNavigatorKey: _rootNavigatorKey,
         builder: (context, state) =>
             VideoPlayerScreen(videoId: state.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/search',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const SearchScreen(),
       ),
     ],
   );

--- a/lib/models/video_page.dart
+++ b/lib/models/video_page.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'video.dart';
+
+part 'video_page.freezed.dart';
+part 'video_page.g.dart';
+
+/// One page of cursor-paginated video search results.
+///
+/// Mirrors the backend `VideoSearchPage`: [items] are this page's videos,
+/// [total] is the full match count (independent of the cursor), and
+/// [nextCursor] is an opaque token to send back as `?cursor=` for the next
+/// page — null on the last page.
+@freezed
+abstract class VideoPage with _$VideoPage {
+  const factory VideoPage({
+    @Default(<Video>[]) List<Video> items,
+    @Default(0) int total,
+    @JsonKey(name: 'next_cursor') String? nextCursor,
+  }) = _VideoPage;
+
+  factory VideoPage.fromJson(Map<String, dynamic> json) =>
+      _$VideoPageFromJson(json);
+}
+
+extension VideoPageExtensions on VideoPage {
+  /// Whether another page can be fetched with [VideoPage.nextCursor].
+  bool get hasMore => nextCursor != null;
+}

--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/channel.dart';
+import '../models/video.dart';
+import '../services/api_service.dart';
+
+/// Immutable state for the search screen: the committed [query], the channel
+/// and video matches, and the pagination/loading bookkeeping that backs the
+/// list states.
+class SearchState {
+  final String query;
+  final List<Channel> channels;
+  final List<Video> videos;
+
+  /// Opaque cursor for the next video page, or null when on the last page.
+  final String? nextCursor;
+
+  /// Total matching videos, independent of how many pages are loaded.
+  final int total;
+
+  /// A new query is loading its first page.
+  final bool isLoading;
+
+  /// A further page is being appended via [SearchNotifier.loadMore].
+  final bool isLoadingMore;
+
+  final String? error;
+
+  const SearchState({
+    this.query = '',
+    this.channels = const [],
+    this.videos = const [],
+    this.nextCursor,
+    this.total = 0,
+    this.isLoading = false,
+    this.isLoadingMore = false,
+    this.error,
+  });
+
+  bool get hasMore => nextCursor != null;
+  bool get hasResults => channels.isNotEmpty || videos.isNotEmpty;
+
+  SearchState copyWith({
+    String? query,
+    List<Channel>? channels,
+    List<Video>? videos,
+    String? nextCursor,
+    bool clearNextCursor = false,
+    int? total,
+    bool? isLoading,
+    bool? isLoadingMore,
+    String? error,
+    bool clearError = false,
+  }) {
+    return SearchState(
+      query: query ?? this.query,
+      channels: channels ?? this.channels,
+      videos: videos ?? this.videos,
+      nextCursor: clearNextCursor ? null : (nextCursor ?? this.nextCursor),
+      total: total ?? this.total,
+      isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}
+
+/// Drives library search: debounces the query, fetches channel + video matches
+/// for the first page, then appends further video pages on demand.
+///
+/// An empty query lists recent library items (videos only — the whole channel
+/// list isn't worth dumping). State only changes from the [search]/[loadMore]
+/// event handlers, never from a widget's build.
+class SearchNotifier extends Notifier<SearchState> {
+  Timer? _debounce;
+
+  /// Bumped on every new query so a slow in-flight response can't overwrite
+  /// the results of a newer one.
+  int _requestId = 0;
+
+  static const _debounceDuration = Duration(milliseconds: 300);
+
+  @override
+  SearchState build() {
+    ref.onDispose(() => _debounce?.cancel());
+    // Load recent library items once the provider is initialized (deferred so
+    // the synchronous part runs after build() returns).
+    Future.microtask(() => _run(''));
+    return const SearchState(isLoading: true);
+  }
+
+  ApiService get _api => ref.read(apiServiceProvider);
+
+  /// Debounced entry point wired to the search field's `onChanged`.
+  void search(String query) {
+    _debounce?.cancel();
+    _debounce = Timer(_debounceDuration, () => _run(query));
+  }
+
+  /// Clears the query immediately (no debounce) and reloads recent items.
+  void clear() {
+    _debounce?.cancel();
+    _run('');
+  }
+
+  /// Re-runs the current query after an error.
+  void retry() => _run(state.query);
+
+  Future<void> _run(String query) async {
+    final q = query.trim();
+    final requestId = ++_requestId;
+    // Reset to a clean loading state so stale results don't linger under the
+    // spinner while the new query resolves.
+    state = state.copyWith(
+      query: q,
+      channels: const [],
+      videos: const [],
+      total: 0,
+      clearNextCursor: true,
+      isLoading: true,
+      isLoadingMore: false,
+      clearError: true,
+    );
+
+    try {
+      // Start both requests before awaiting so they run concurrently. Channel
+      // search is skipped for the empty (recent) query.
+      final pageFuture = _api.searchVideos(q: q.isEmpty ? null : q);
+      final channelsFuture = q.isEmpty
+          ? Future.value(<Channel>[])
+          : _api.searchChannels(q);
+      final page = await pageFuture;
+      final channels = await channelsFuture;
+      if (requestId != _requestId) return;
+      state = state.copyWith(
+        channels: channels,
+        videos: page.items,
+        nextCursor: page.nextCursor,
+        clearNextCursor: page.nextCursor == null,
+        total: page.total,
+        isLoading: false,
+      );
+    } catch (e) {
+      if (requestId != _requestId) return;
+      state = state.copyWith(
+        isLoading: false,
+        error: e is ApiException
+            ? e.message
+            : 'Search failed. Please try again.',
+      );
+    }
+  }
+
+  /// Appends the next video page. No-op while a query loads, while already
+  /// appending, or once the last page has been reached.
+  Future<void> loadMore() async {
+    if (state.isLoading || state.isLoadingMore || state.nextCursor == null) {
+      return;
+    }
+    final requestId = _requestId;
+    final cursor = state.nextCursor;
+    final q = state.query;
+    state = state.copyWith(isLoadingMore: true);
+    try {
+      final page = await _api.searchVideos(
+        q: q.isEmpty ? null : q,
+        cursor: cursor,
+      );
+      // A new query started while this page was in flight — drop the result.
+      if (requestId != _requestId) return;
+      state = state.copyWith(
+        videos: [...state.videos, ...page.items],
+        nextCursor: page.nextCursor,
+        clearNextCursor: page.nextCursor == null,
+        total: page.total,
+        isLoadingMore: false,
+      );
+    } catch (_) {
+      if (requestId != _requestId) return;
+      // Keep what's loaded; just stop the footer spinner.
+      state = state.copyWith(isLoadingMore: false);
+    }
+  }
+}
+
+final searchProvider = NotifierProvider<SearchNotifier, SearchState>(
+  SearchNotifier.new,
+);

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -149,6 +149,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               title: const Text('Library'),
               backgroundColor: NullFeedTheme.backgroundColor,
               actions: [
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  tooltip: 'Search',
+                  onPressed: () => context.push('/search'),
+                ),
                 PopupMenuButton<_LibrarySort>(
                   icon: const Icon(Icons.sort),
                   tooltip: 'Sort',

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../models/channel.dart';
+import '../providers/feed_provider.dart';
+import '../providers/search_provider.dart';
+import '../widgets/video_list_tile.dart';
+import '../config/theme.dart';
+
+/// Full-screen library search reached from the Library app bar. The query is
+/// debounced in [SearchNotifier]; video results paginate via `next_cursor` as
+/// the user scrolls. Tapping a video opens the player; tapping a channel opens
+/// the channel.
+class SearchScreen extends ConsumerStatefulWidget {
+  const SearchScreen({super.key});
+
+  @override
+  ConsumerState<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends ConsumerState<SearchScreen> {
+  late final TextEditingController _controller;
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Seed the field from any query the (kept-alive) provider already holds so
+    // the text and the on-screen results always agree.
+    _controller = TextEditingController(text: ref.read(searchProvider).query);
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    // Prefetch the next page a little before hitting the very bottom.
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 400) {
+      ref.read(searchProvider.notifier).loadMore();
+    }
+  }
+
+  Future<void> _openVideo(String id) async {
+    await context.push('/player/$id');
+    if (!mounted) return;
+    // Watch positions may have changed — keep the home feed fresh.
+    invalidateFeedProviders(ref);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(searchProvider);
+    final notifier = ref.read(searchProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: NullFeedTheme.backgroundColor,
+        titleSpacing: 0,
+        title: TextField(
+          controller: _controller,
+          autofocus: true,
+          textInputAction: TextInputAction.search,
+          onChanged: notifier.search,
+          style: const TextStyle(
+            color: NullFeedTheme.textPrimary,
+            fontSize: 18,
+          ),
+          decoration: InputDecoration(
+            hintText: 'Search videos and channels',
+            filled: false,
+            border: InputBorder.none,
+            enabledBorder: InputBorder.none,
+            focusedBorder: InputBorder.none,
+            suffixIcon: ValueListenableBuilder<TextEditingValue>(
+              valueListenable: _controller,
+              builder: (context, value, _) {
+                if (value.text.isEmpty) return const SizedBox.shrink();
+                return IconButton(
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Clear',
+                  onPressed: () {
+                    _controller.clear();
+                    notifier.clear();
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+      body: _SearchBody(
+        state: state,
+        scrollController: _scrollController,
+        onRetry: notifier.retry,
+        onVideoTap: _openVideo,
+        onChannelTap: (id) => context.push('/channel/$id'),
+      ),
+    );
+  }
+}
+
+class _SearchBody extends StatelessWidget {
+  const _SearchBody({
+    required this.state,
+    required this.scrollController,
+    required this.onRetry,
+    required this.onVideoTap,
+    required this.onChannelTap,
+  });
+
+  final SearchState state;
+  final ScrollController scrollController;
+  final VoidCallback onRetry;
+  final ValueChanged<String> onVideoTap;
+  final ValueChanged<String> onChannelTap;
+
+  @override
+  Widget build(BuildContext context) {
+    // First load / error / empty all take over the whole screen; once there
+    // are results they stay put and loading happens in-place.
+    if (state.isLoading && !state.hasResults) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (state.error != null && !state.hasResults) {
+      return _SearchMessage(
+        icon: Icons.error_outline,
+        iconColor: NullFeedTheme.errorColor,
+        title: 'Search failed',
+        message: state.error!,
+        onRetry: onRetry,
+      );
+    }
+    if (!state.hasResults) {
+      final isQuery = state.query.isNotEmpty;
+      return _SearchMessage(
+        icon: isQuery ? Icons.search_off : Icons.video_library_outlined,
+        iconColor: NullFeedTheme.textMuted,
+        title: isQuery
+            ? 'No results for "${state.query}"'
+            : 'Your library is empty',
+        message: isQuery
+            ? 'Try a different title or channel name.'
+            : 'Videos you add to your library will show up here.',
+      );
+    }
+
+    final slivers = <Widget>[
+      if (state.channels.isNotEmpty)
+        SliverToBoxAdapter(
+          child: _ChannelResults(channels: state.channels, onTap: onChannelTap),
+        ),
+      if (state.videos.isNotEmpty) ...[
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              state.query.isEmpty ? 'Recent' : 'Videos',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ),
+        SliverList(
+          delegate: SliverChildBuilderDelegate((context, index) {
+            final video = state.videos[index];
+            return VideoListTile(
+              video: video,
+              onTap: () => onVideoTap(video.id),
+            );
+          }, childCount: state.videos.length),
+        ),
+        SliverToBoxAdapter(
+          child: SizedBox(
+            height: 64,
+            child: Center(
+              child: state.isLoadingMore
+                  ? const CircularProgressIndicator()
+                  : const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      ],
+    ];
+
+    return CustomScrollView(
+      controller: scrollController,
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      slivers: slivers,
+    );
+  }
+}
+
+/// Horizontal strip of channel matches shown above the video results.
+class _ChannelResults extends StatelessWidget {
+  const _ChannelResults({required this.channels, required this.onTap});
+
+  final List<Channel> channels;
+  final ValueChanged<String> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Text(
+            'Channels',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ),
+        SizedBox(
+          height: 116,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: channels.length,
+            separatorBuilder: (_, __) => const SizedBox(width: 12),
+            itemBuilder: (context, index) {
+              final channel = channels[index];
+              return _ChannelChip(
+                channel: channel,
+                onTap: () => onTap(channel.id),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ChannelChip extends StatelessWidget {
+  const _ChannelChip({required this.channel, required this.onTap});
+
+  final Channel channel;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: SizedBox(
+        width: 80,
+        child: Column(
+          children: [
+            if (channel.avatarUrl != null)
+              CircleAvatar(
+                radius: 32,
+                backgroundColor: NullFeedTheme.cardColor,
+                backgroundImage: CachedNetworkImageProvider(channel.avatarUrl!),
+              )
+            else
+              CircleAvatar(
+                radius: 32,
+                backgroundColor: NullFeedTheme.primaryColor.withValues(
+                  alpha: 0.2,
+                ),
+                child: Text(
+                  channel.name.isNotEmpty ? channel.name[0].toUpperCase() : '?',
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: NullFeedTheme.primaryColor,
+                  ),
+                ),
+              ),
+            const SizedBox(height: 6),
+            Text(
+              channel.name,
+              maxLines: 2,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Centered full-screen state (empty / error), with an optional Retry button.
+class _SearchMessage extends StatelessWidget {
+  const _SearchMessage({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.message,
+    this.onRetry,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: iconColor),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 16),
+              OutlinedButton(onPressed: onRetry, child: const Text('Retry')),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -4,6 +4,7 @@ import '../config/constants.dart';
 import '../models/user.dart';
 import '../models/channel.dart';
 import '../models/video.dart';
+import '../models/video_page.dart';
 import '../models/feed.dart';
 import '../models/recommendation.dart';
 import '../models/youtube_import.dart';
@@ -402,6 +403,45 @@ class ApiService {
     final base = '$_baseUrl${AppConstants.videoPreviewStream(id)}';
     return token != null ? '$base?token=$token' : base;
   }
+
+  // Search
+
+  /// Searches the caller's library, matching [q] against video title or
+  /// channel name. Returns one cursor-paginated page; pass
+  /// [VideoPage.nextCursor] back as [cursor] for the next page (null = last
+  /// page). An empty/absent [q] lists the whole library, newest-first.
+  Future<VideoPage> searchVideos({
+    String? q,
+    String? status,
+    bool? watched,
+    String? channelId,
+    String? cursor,
+    int limit = 20,
+  }) => _guard(() async {
+    final response = await _dio.get(
+      '$_baseUrl${AppConstants.videos}',
+      queryParameters: {
+        if (q != null && q.isNotEmpty) 'q': q,
+        if (status != null) 'status': status,
+        if (watched != null) 'watched': watched,
+        if (channelId != null) 'channel_id': channelId,
+        if (cursor != null) 'cursor': cursor,
+        'limit': limit,
+      },
+    );
+    return VideoPage.fromJson(response.data as Map<String, dynamic>);
+  });
+
+  /// Filters subscribed channels by name. Backs the channel section of search.
+  Future<List<Channel>> searchChannels(String q) => _guard(() async {
+    final response = await _dio.get(
+      '$_baseUrl${AppConstants.channels}',
+      queryParameters: {'q': q},
+    );
+    return (response.data as List)
+        .map((json) => Channel.fromJson(json as Map<String, dynamic>))
+        .toList();
+  });
 
   // Feed
 

--- a/test/unit/models_test.dart
+++ b/test/unit/models_test.dart
@@ -4,6 +4,7 @@ import 'package:nullfeed/models/feed.dart';
 import 'package:nullfeed/models/json_converters.dart';
 import 'package:nullfeed/models/user.dart';
 import 'package:nullfeed/models/video.dart';
+import 'package:nullfeed/models/video_page.dart';
 import 'package:nullfeed/models/youtube_import.dart';
 
 void main() {
@@ -256,6 +257,50 @@ void main() {
       expect(channel.lastCheckedAt, DateTime.utc(2026, 6, 11, 9, 15));
       expect(channel.lastCheckedAt!.isUtc, isTrue);
       expect(Channel.fromJson(channel.toJson()), channel);
+    });
+  });
+
+  group('VideoPage', () {
+    Map<String, dynamic> videoJson(String id) => {
+      'id': id,
+      'youtube_video_id': 'yt-$id',
+      'channel_id': 'c1',
+      'title': 'Video $id',
+    };
+
+    test('parses items, total and next_cursor (a non-final page)', () {
+      final page = VideoPage.fromJson({
+        'items': [videoJson('v1'), videoJson('v2')],
+        'total': 7,
+        'next_cursor': 'opaque-cursor-token',
+      });
+
+      expect(page.items, hasLength(2));
+      expect(page.items.first.id, 'v1');
+      expect(page.items.first.title, 'Video v1');
+      expect(page.total, 7);
+      expect(page.nextCursor, 'opaque-cursor-token');
+      expect(page.hasMore, isTrue);
+    });
+
+    test('treats a null next_cursor as the last page', () {
+      final page = VideoPage.fromJson({
+        'items': [videoJson('v1')],
+        'total': 1,
+        'next_cursor': null,
+      });
+
+      expect(page.nextCursor, isNull);
+      expect(page.hasMore, isFalse);
+    });
+
+    test('defaults items to empty and total to 0 when keys are absent', () {
+      final page = VideoPage.fromJson(const {});
+
+      expect(page.items, isEmpty);
+      expect(page.total, 0);
+      expect(page.nextCursor, isNull);
+      expect(page.hasMore, isFalse);
     });
   });
 }

--- a/test/unit/search_notifier_test.dart
+++ b/test/unit/search_notifier_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nullfeed/models/channel.dart';
+import 'package:nullfeed/models/video.dart';
+import 'package:nullfeed/models/video_page.dart';
+import 'package:nullfeed/providers/search_provider.dart';
+import 'package:nullfeed/services/api_service.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  late MockApiService api;
+
+  setUp(() {
+    api = MockApiService();
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [apiServiceProvider.overrideWithValue(api)],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Video video(String id, {String title = 'A Video'}) =>
+      Video(id: id, youtubeVideoId: 'yt-$id', channelId: 'c1', title: title);
+
+  Channel channel(String id, String name) => Channel(
+    id: id,
+    youtubeChannelId: 'UC-$id',
+    name: name,
+    slug: name.toLowerCase(),
+  );
+
+  /// Lets [SearchNotifier.build]'s deferred recent-load and any awaited API
+  /// calls finish, without tripping the 300ms search debounce.
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 20));
+
+  /// Long enough for the debounce timer started by [SearchNotifier.search].
+  Future<void> debounce() =>
+      Future<void>.delayed(const Duration(milliseconds: 350));
+
+  group('initial load', () {
+    test(
+      'lists recent library videos (empty query, no channel call)',
+      () async {
+        when(() => api.searchVideos()).thenAnswer(
+          (_) async => VideoPage(items: [video('v1'), video('v2')], total: 2),
+        );
+        final container = createContainer();
+
+        container.read(searchProvider);
+        await settle();
+
+        final state = container.read(searchProvider);
+        expect(state.query, '');
+        expect(state.videos.map((v) => v.id), ['v1', 'v2']);
+        expect(state.channels, isEmpty);
+        expect(state.isLoading, isFalse);
+        expect(state.hasResults, isTrue);
+        // The empty (recent) query must not dump the whole channel list.
+        verifyNever(() => api.searchChannels(any()));
+      },
+    );
+
+    test('reports no results when the library is empty', () async {
+      when(() => api.searchVideos()).thenAnswer((_) async => const VideoPage());
+      final container = createContainer();
+
+      container.read(searchProvider);
+      await settle();
+
+      final state = container.read(searchProvider);
+      expect(state.hasResults, isFalse);
+      expect(state.isLoading, isFalse);
+      expect(state.error, isNull);
+    });
+
+    test('surfaces an ApiException message as the error', () async {
+      when(() => api.searchVideos()).thenThrow(
+        const ApiException(message: 'Server exploded', statusCode: 500),
+      );
+      final container = createContainer();
+
+      container.read(searchProvider);
+      await settle();
+
+      final state = container.read(searchProvider);
+      expect(state.error, 'Server exploded');
+      expect(state.isLoading, isFalse);
+      expect(state.hasResults, isFalse);
+    });
+  });
+
+  group('querying', () {
+    test('debounced query fetches channels + videos and total', () async {
+      when(() => api.searchVideos()).thenAnswer((_) async => const VideoPage());
+      when(() => api.searchVideos(q: 'cats')).thenAnswer(
+        (_) async => VideoPage(items: [video('v1', title: 'Cats')], total: 1),
+      );
+      when(
+        () => api.searchChannels('cats'),
+      ).thenAnswer((_) async => [channel('c9', 'Cool Cats')]);
+      final container = createContainer();
+      container.read(searchProvider);
+      await settle();
+
+      container.read(searchProvider.notifier).search('cats');
+      await debounce();
+
+      final state = container.read(searchProvider);
+      expect(state.query, 'cats');
+      expect(state.videos.single.title, 'Cats');
+      expect(state.channels.single.name, 'Cool Cats');
+      expect(state.total, 1);
+      expect(state.isLoading, isFalse);
+    });
+  });
+
+  group('pagination', () {
+    test(
+      'loadMore appends the next page and clears the final cursor',
+      () async {
+        when(() => api.searchVideos()).thenAnswer(
+          (_) async =>
+              VideoPage(items: [video('v1')], total: 3, nextCursor: 'c1'),
+        );
+        when(() => api.searchVideos(cursor: 'c1')).thenAnswer(
+          (_) async => VideoPage(items: [video('v2'), video('v3')], total: 3),
+        );
+        final container = createContainer();
+        container.read(searchProvider);
+        await settle();
+        expect(container.read(searchProvider).hasMore, isTrue);
+
+        await container.read(searchProvider.notifier).loadMore();
+
+        final state = container.read(searchProvider);
+        expect(state.videos.map((v) => v.id), ['v1', 'v2', 'v3']);
+        expect(state.nextCursor, isNull);
+        expect(state.hasMore, isFalse);
+        expect(state.isLoadingMore, isFalse);
+      },
+    );
+
+    test('loadMore is a no-op once on the last page', () async {
+      when(
+        () => api.searchVideos(),
+      ).thenAnswer((_) async => VideoPage(items: [video('v1')], total: 1));
+      final container = createContainer();
+      container.read(searchProvider);
+      await settle();
+
+      await container.read(searchProvider.notifier).loadMore();
+
+      // Only the initial recent load hit the API — no cursor page was fetched.
+      verify(() => api.searchVideos()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Flutter search UI (roadmap LATER tier, #1 client) consuming the new search API.

## What
- A search screen (reached from the Library) with a **debounced** query (Timer-based) hitting `GET /api/videos?q=&cursor=` and `GET /api/channels?q=`.
- Channel matches + a cursor-**paginated** video list (`loadMore` appends via `next_cursor`; `hasMore` = cursor present). Tap a video to play, a channel to open it.
- Loading / empty / error states; search state lives in a `SearchNotifier` (off the build phase).
- New `VideoPage` model (`items`, `total`, `nextCursor`) + `ApiService.searchVideos`/`searchChannels`.

## Verification (local)
- `dart format` — clean · `flutter analyze` — No issues found · `flutter test` — all pass (+ new `models_test` for `VideoPage` and `search_notifier_test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY