### PR TITLE
feat: cache last-good catalog for offline browsing

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -10,6 +10,11 @@ class AppConstants {
   static const String sessionBox = 'session';
   static const String offlineBox = 'offline_videos';
 
+  /// Last-good catalog snapshot (channel list, home feed, per-channel video
+  /// lists) persisted so the app stays browsable offline. Entries are scoped
+  /// by the active profile — see [CatalogCacheService].
+  static const String catalogCacheBox = 'catalog_cache';
+
   // Hive keys
   static const String serverUrlKey = 'server_url';
   static const String selectedUserIdKey = 'selected_user_id';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ void main() async {
   await Hive.openBox(AppConstants.settingsBox);
   await Hive.openBox(AppConstants.sessionBox);
   await Hive.openBox(AppConstants.offlineBox);
+  await Hive.openBox(AppConstants.catalogCacheBox);
 
   runApp(const ProviderScope(child: NullFeedApp()));
 }

--- a/lib/providers/channel_provider.dart
+++ b/lib/providers/channel_provider.dart
@@ -2,23 +2,43 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/channel.dart';
 import '../models/video.dart';
 import '../services/api_service.dart';
+import '../services/catalog_cache_service.dart';
 
+/// The subscribed channel list. Hydrates from the per-profile cache instantly
+/// on build (so the Library tab shows last-known channels offline without a
+/// spinner), then refreshes in the background and writes the result through to
+/// the cache. A connection error falls back to the cache; a real server error
+/// still surfaces.
 class ChannelsNotifier extends Notifier<AsyncValue<List<Channel>>> {
   @override
   AsyncValue<List<Channel>> build() {
-    load();
-    return const AsyncValue.loading();
+    final cached = _cache.readChannels();
+    // Deferred so the load runs after build() returns and `state` exists.
+    Future.microtask(load);
+    return cached != null
+        ? AsyncValue.data(cached)
+        : const AsyncValue.loading();
   }
 
   ApiService get _api => ref.read(apiServiceProvider);
+  CatalogCacheService get _cache => ref.read(catalogCacheServiceProvider);
 
   Future<void> load() async {
-    state = const AsyncValue.loading();
+    // The build-time load is deferred, and screens invalidate this provider
+    // while a fetch is in flight; bail if this element was disposed meanwhile.
+    if (!ref.mounted) return;
+    final api = _api;
+    final cache = _cache;
+    // Keep cached channels on screen while refetching; only spin when empty.
+    if (!state.hasValue) state = const AsyncValue.loading();
     try {
-      final channels = await _api.getChannels();
-      state = AsyncValue.data(channels);
+      final channels = await api.getChannels();
+      await cache.writeChannels(channels);
+      if (ref.mounted) state = AsyncValue.data(channels);
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (ref.mounted) {
+        state = resolveCatalogRefreshError(e, st, state, cache.readChannels());
+      }
     }
   }
 
@@ -45,18 +65,106 @@ final channelsProvider =
       ChannelsNotifier.new,
     );
 
-final channelDetailProvider = FutureProvider.family<Channel, String>((
-  ref,
-  channelId,
-) async {
-  final api = ref.watch(apiServiceProvider);
-  return api.getChannel(channelId);
-});
+/// A single channel's detail. Hydrates from the per-profile cache instantly so
+/// the channel screen header shows offline, then refreshes and writes through.
+/// Connection errors fall back to the cache; real errors surface.
+class ChannelDetailNotifier extends Notifier<AsyncValue<Channel>> {
+  late final String _channelId;
 
-final channelVideosProvider = FutureProvider.family<List<Video>, String>((
-  ref,
-  channelId,
-) async {
-  final api = ref.watch(apiServiceProvider);
-  return api.getChannelVideos(channelId);
-});
+  void init(String channelId) => _channelId = channelId;
+
+  @override
+  AsyncValue<Channel> build() {
+    final cached = _cache.readChannel(_channelId);
+    Future.microtask(refresh);
+    return cached != null
+        ? AsyncValue.data(cached)
+        : const AsyncValue.loading();
+  }
+
+  ApiService get _api => ref.read(apiServiceProvider);
+  CatalogCacheService get _cache => ref.read(catalogCacheServiceProvider);
+
+  Future<void> refresh() async {
+    if (!ref.mounted) return;
+    final api = _api;
+    final cache = _cache;
+    if (!state.hasValue) state = const AsyncValue.loading();
+    try {
+      final channel = await api.getChannel(_channelId);
+      await cache.writeChannel(channel);
+      if (ref.mounted) state = AsyncValue.data(channel);
+    } catch (e, st) {
+      if (ref.mounted) {
+        state = resolveCatalogRefreshError(
+          e,
+          st,
+          state,
+          cache.readChannel(_channelId),
+        );
+      }
+    }
+  }
+}
+
+final channelDetailProvider =
+    NotifierProvider.family<ChannelDetailNotifier, AsyncValue<Channel>, String>(
+      (channelId) {
+        final notifier = ChannelDetailNotifier();
+        notifier.init(channelId);
+        return notifier;
+      },
+    );
+
+/// A channel's video list. Hydrates from the per-profile cache instantly so the
+/// channel screen lists last-known videos offline, then refreshes and writes
+/// through. Connection errors fall back to the cache; real errors surface.
+class ChannelVideosNotifier extends Notifier<AsyncValue<List<Video>>> {
+  late final String _channelId;
+
+  void init(String channelId) => _channelId = channelId;
+
+  @override
+  AsyncValue<List<Video>> build() {
+    final cached = _cache.readChannelVideos(_channelId);
+    Future.microtask(refresh);
+    return cached != null
+        ? AsyncValue.data(cached)
+        : const AsyncValue.loading();
+  }
+
+  ApiService get _api => ref.read(apiServiceProvider);
+  CatalogCacheService get _cache => ref.read(catalogCacheServiceProvider);
+
+  Future<void> refresh() async {
+    if (!ref.mounted) return;
+    final api = _api;
+    final cache = _cache;
+    if (!state.hasValue) state = const AsyncValue.loading();
+    try {
+      final videos = await api.getChannelVideos(_channelId);
+      await cache.writeChannelVideos(_channelId, videos);
+      if (ref.mounted) state = AsyncValue.data(videos);
+    } catch (e, st) {
+      if (ref.mounted) {
+        state = resolveCatalogRefreshError(
+          e,
+          st,
+          state,
+          cache.readChannelVideos(_channelId),
+        );
+      }
+    }
+  }
+}
+
+final channelVideosProvider =
+    NotifierProvider.family<
+      ChannelVideosNotifier,
+      AsyncValue<List<Video>>,
+      String
+    >((channelId) {
+      final notifier = ChannelVideosNotifier();
+      notifier.init(channelId);
+      return notifier;
+    });

--- a/lib/providers/feed_provider.dart
+++ b/lib/providers/feed_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/feed.dart';
 import '../services/api_service.dart';
+import '../services/catalog_cache_service.dart';
 
 final continueWatchingProvider = FutureProvider<List<FeedItem>>((ref) async {
   final api = ref.watch(apiServiceProvider);
@@ -31,7 +32,46 @@ void invalidateFeedProviders(WidgetRef ref) {
 /// The unified home feed (all three rows in a single request). This is what
 /// the home screen watches; [continueWatchingProvider] and friends remain for
 /// callers that need one row at a time.
-final homeFeedProvider = FutureProvider<HomeFeed>((ref) async {
-  final api = ref.watch(apiServiceProvider);
-  return api.getHomeFeed();
-});
+///
+/// Hydrates from the per-profile cache instantly on build so launch shows the
+/// last-known feed without a spinner, then refreshes in the background and
+/// writes the result through to the cache. A connection error falls back to the
+/// cached feed instead of surfacing; a real server error still surfaces.
+class HomeFeedNotifier extends Notifier<AsyncValue<HomeFeed>> {
+  @override
+  AsyncValue<HomeFeed> build() {
+    final cached = _cache.readHomeFeed();
+    // Deferred so the refresh runs after build() returns and `state` exists.
+    Future.microtask(refresh);
+    return cached != null
+        ? AsyncValue.data(cached)
+        : const AsyncValue.loading();
+  }
+
+  ApiService get _api => ref.read(apiServiceProvider);
+  CatalogCacheService get _cache => ref.read(catalogCacheServiceProvider);
+
+  Future<void> refresh() async {
+    // The build-time refresh is deferred, and screens invalidate this provider
+    // while a fetch is in flight; bail if this element was disposed meanwhile.
+    if (!ref.mounted) return;
+    final api = _api;
+    final cache = _cache;
+    // Keep cached content on screen while refetching; only spin when empty.
+    if (!state.hasValue) state = const AsyncValue.loading();
+    try {
+      final feed = await api.getHomeFeed();
+      await cache.writeHomeFeed(feed);
+      if (ref.mounted) state = AsyncValue.data(feed);
+    } catch (e, st) {
+      if (ref.mounted) {
+        state = resolveCatalogRefreshError(e, st, state, cache.readHomeFeed());
+      }
+    }
+  }
+}
+
+final homeFeedProvider =
+    NotifierProvider<HomeFeedNotifier, AsyncValue<HomeFeed>>(
+      HomeFeedNotifier.new,
+    );

--- a/lib/screens/channel_detail_screen.dart
+++ b/lib/screens/channel_detail_screen.dart
@@ -121,14 +121,12 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
       // Poll failures (offline server, YouTube hiccup) shouldn't block
       // refreshing what we already have.
     }
-    try {
-      await Future.wait([
-        ref.refresh(channelDetailProvider(widget.channelId).future),
-        ref.refresh(channelVideosProvider(widget.channelId).future),
-      ]);
-    } catch (_) {
-      // Errors surface through the providers' error states.
-    }
+    // Each refresh() resolves its own errors into state (cache fallback on a
+    // connection error), so neither throws.
+    await Future.wait([
+      ref.read(channelDetailProvider(widget.channelId).notifier).refresh(),
+      ref.read(channelVideosProvider(widget.channelId).notifier).refresh(),
+    ]);
   }
 
   /// Picks the video for the Resume/Play button:

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -74,12 +74,9 @@ class HomeScreen extends ConsumerWidget {
         ref.read(apiServiceProvider).pollAllChannels().catchError((_) {}),
       );
       // Reload the unified feed and keep the spinner up until it resolves.
-      final reload = ref.refresh(homeFeedProvider.future);
-      try {
-        await reload;
-      } catch (_) {
-        // The inline error state renders instead.
-      }
+      // refresh() resolves its own errors into state (cache fallback on a
+      // connection error), so it never throws.
+      await ref.read(homeFeedProvider.notifier).refresh();
     }
 
     return Scaffold(

--- a/lib/services/catalog_cache_service.dart
+++ b/lib/services/catalog_cache_service.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import '../config/constants.dart';
+import '../models/channel.dart';
+import '../models/feed.dart';
+import '../models/video.dart';
+import 'api_service.dart';
+import 'storage_service.dart';
+
+final catalogCacheServiceProvider = Provider<CatalogCacheService>((ref) {
+  final storage = ref.watch(storageServiceProvider);
+  return CatalogCacheService(storage: storage);
+});
+
+/// Maps a failed catalog refresh to the next [AsyncValue], shared by the
+/// cache-backed catalog notifiers.
+///
+/// A connection error ([ApiException.isConnectionError]) falls back to [cached]
+/// when present, otherwise keeps the [current] value if there is one, and only
+/// surfaces the error when there's nothing to show (a cold offline start). Any
+/// other error — a real server error — surfaces.
+AsyncValue<T> resolveCatalogRefreshError<T>(
+  Object error,
+  StackTrace stackTrace,
+  AsyncValue<T> current,
+  T? cached,
+) {
+  if (error is ApiException && error.isConnectionError) {
+    if (cached != null) return AsyncValue.data(cached);
+    if (current.hasValue) return current;
+  }
+  return AsyncValue.error(error, stackTrace);
+}
+
+/// Persists the last-good catalog — the channel list, the home feed, and
+/// per-channel video/detail snapshots — to Hive so the app stays browsable
+/// when the server is unreachable.
+///
+/// Entries are the Freezed models' JSON (`toJson`) stored as a string, which
+/// round-trips through the same `fromJson` the network path uses. Every key is
+/// scoped to the active profile ([StorageService.getSelectedUserId]) so
+/// switching profiles never surfaces another profile's catalog, and a re-login
+/// as the same profile keeps its cache. Reads and writes are no-ops while
+/// signed out (no scope).
+class CatalogCacheService {
+  CatalogCacheService({required this.storage});
+
+  final StorageService storage;
+
+  Box get _box => Hive.box(AppConstants.catalogCacheBox);
+
+  /// The active profile's id, or null when signed out.
+  String? get _scope => storage.getSelectedUserId();
+
+  /// Builds a profile-scoped key, or null when there is no active profile (in
+  /// which case callers skip the read/write entirely).
+  String? _key(String suffix) {
+    final scope = _scope;
+    return scope == null ? null : '$scope::$suffix';
+  }
+
+  // --- Channel list -------------------------------------------------------
+
+  List<Channel>? readChannels() =>
+      _readList(_key('channels'), Channel.fromJson);
+
+  Future<void> writeChannels(List<Channel> channels) =>
+      _writeJson(_key('channels'), [for (final c in channels) c.toJson()]);
+
+  // --- Home feed ----------------------------------------------------------
+
+  HomeFeed? readHomeFeed() => _readObject(_key('home_feed'), HomeFeed.fromJson);
+
+  Future<void> writeHomeFeed(HomeFeed feed) =>
+      _writeJson(_key('home_feed'), feed.toJson());
+
+  // --- Channel detail -----------------------------------------------------
+
+  Channel? readChannel(String channelId) =>
+      _readObject(_key('channel::$channelId'), Channel.fromJson);
+
+  Future<void> writeChannel(Channel channel) =>
+      _writeJson(_key('channel::${channel.id}'), channel.toJson());
+
+  // --- Per-channel video list ---------------------------------------------
+
+  List<Video>? readChannelVideos(String channelId) =>
+      _readList(_key('channel_videos::$channelId'), Video.fromJson);
+
+  Future<void> writeChannelVideos(String channelId, List<Video> videos) =>
+      _writeJson(_key('channel_videos::$channelId'), [
+        for (final v in videos) v.toJson(),
+      ]);
+
+  // --- Generic helpers ----------------------------------------------------
+
+  String? _read(String? key) {
+    if (key == null) return null;
+    final value = _box.get(key);
+    return value is String ? value : null;
+  }
+
+  Future<void> _writeJson(String? key, Object json) async {
+    if (key == null) return;
+    await _box.put(key, jsonEncode(json));
+  }
+
+  T? _readObject<T>(String? key, T Function(Map<String, dynamic>) fromJson) {
+    final raw = _read(key);
+    if (raw == null) return null;
+    try {
+      return fromJson((jsonDecode(raw) as Map).cast<String, dynamic>());
+    } catch (_) {
+      // Corrupt or stale-schema entry — ignore and fall through to a refetch.
+      return null;
+    }
+  }
+
+  List<T>? _readList<T>(
+    String? key,
+    T Function(Map<String, dynamic>) fromJson,
+  ) {
+    final raw = _read(key);
+    if (raw == null) return null;
+    try {
+      return (jsonDecode(raw) as List)
+          .map((e) => fromJson((e as Map).cast<String, dynamic>()))
+          .toList();
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -3,7 +3,10 @@ import 'dart:io';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nullfeed/config/constants.dart';
+import 'package:nullfeed/models/channel.dart';
+import 'package:nullfeed/models/feed.dart';
 import 'package:nullfeed/models/user.dart';
+import 'package:nullfeed/models/video.dart';
 import 'package:nullfeed/models/youtube_import.dart';
 import 'package:nullfeed/services/api_service.dart';
 import 'package:nullfeed/services/storage_service.dart';
@@ -105,6 +108,7 @@ Future<Directory> setUpTestHive() async {
   await Hive.openBox<dynamic>(AppConstants.settingsBox);
   await Hive.openBox<dynamic>(AppConstants.sessionBox);
   await Hive.openBox<dynamic>(AppConstants.offlineBox);
+  await Hive.openBox<dynamic>(AppConstants.catalogCacheBox);
   return dir;
 }
 
@@ -161,5 +165,48 @@ ChannelSuggestion makeSuggestion({
     name: name,
     source: source,
     score: score,
+  );
+}
+
+Channel makeChannel({
+  String id = 'c1',
+  String youtubeChannelId = 'UC-c1',
+  String name = 'Some Channel',
+  String slug = 'some-channel',
+  String? avatarUrl,
+  DateTime? lastCheckedAt,
+}) {
+  return Channel(
+    id: id,
+    youtubeChannelId: youtubeChannelId,
+    name: name,
+    slug: slug,
+    avatarUrl: avatarUrl,
+    lastCheckedAt: lastCheckedAt,
+  );
+}
+
+Video makeVideo({
+  String id = 'v1',
+  String youtubeVideoId = 'yt-v1',
+  String channelId = 'c1',
+  String title = 'A Video',
+  int durationSeconds = 600,
+  VideoStatus status = VideoStatus.complete,
+}) {
+  return Video(
+    id: id,
+    youtubeVideoId: youtubeVideoId,
+    channelId: channelId,
+    title: title,
+    durationSeconds: durationSeconds,
+    status: status,
+  );
+}
+
+FeedItem makeFeedItem({Channel? channel, Video? video}) {
+  return FeedItem(
+    channel: channel ?? makeChannel(),
+    video: video ?? makeVideo(),
   );
 }

--- a/test/unit/catalog_cache_fallback_test.dart
+++ b/test/unit/catalog_cache_fallback_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nullfeed/models/feed.dart';
+import 'package:nullfeed/providers/channel_provider.dart';
+import 'package:nullfeed/providers/feed_provider.dart';
+import 'package:nullfeed/services/api_service.dart';
+import 'package:nullfeed/services/catalog_cache_service.dart';
+import 'package:nullfeed/services/storage_service.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  late Directory hiveDir;
+  late MockApiService api;
+  late FakeStorageService storage;
+
+  const connectionError = ApiException(
+    message: 'Could not reach the server. Check your connection.',
+    isConnectionError: true,
+  );
+  const serverError = ApiException(message: 'boom', statusCode: 500);
+
+  setUp(() async {
+    hiveDir = await setUpTestHive();
+    api = MockApiService();
+    storage = FakeStorageService();
+    await storage.setSelectedUserId('u1');
+  });
+
+  tearDown(() async {
+    await tearDownTestHive(hiveDir);
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        apiServiceProvider.overrideWithValue(api),
+        storageServiceProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  CatalogCacheService cacheOf(ProviderContainer c) =>
+      c.read(catalogCacheServiceProvider);
+
+  group('channelsProvider', () {
+    test('writes through to the cache on a successful load', () async {
+      final channels = [makeChannel(id: 'c1')];
+      when(() => api.getChannels()).thenAnswer((_) async => channels);
+      final container = createContainer();
+
+      await container.read(channelsProvider.notifier).load();
+
+      expect(container.read(channelsProvider).value, channels);
+      expect(cacheOf(container).readChannels(), channels);
+    });
+
+    test('falls back to cached channels on a connection error', () async {
+      final cached = [makeChannel(id: 'c1', name: 'Cached')];
+      final container = createContainer();
+      await cacheOf(container).writeChannels(cached);
+      when(() => api.getChannels()).thenThrow(connectionError);
+
+      await container.read(channelsProvider.notifier).load();
+
+      final state = container.read(channelsProvider);
+      expect(state.hasError, isFalse);
+      expect(state.value, cached);
+    });
+
+    test('surfaces a real server error', () async {
+      final container = createContainer();
+      when(() => api.getChannels()).thenThrow(serverError);
+
+      await container.read(channelsProvider.notifier).load();
+
+      expect(container.read(channelsProvider).hasError, isTrue);
+    });
+
+    test('surfaces a connection error when nothing is cached', () async {
+      final container = createContainer();
+      when(() => api.getChannels()).thenThrow(connectionError);
+
+      await container.read(channelsProvider.notifier).load();
+
+      expect(container.read(channelsProvider).hasError, isTrue);
+    });
+  });
+
+  group('homeFeedProvider', () {
+    test('hydrates from cache instantly, then refreshes through', () async {
+      final cachedFeed = HomeFeed(recentlyAdded: [makeFeedItem()]);
+      final fresh = HomeFeed(
+        newEpisodes: [makeFeedItem(video: makeVideo(id: 'v2'))],
+      );
+      final container = createContainer();
+      await cacheOf(container).writeHomeFeed(cachedFeed);
+      when(() => api.getHomeFeed()).thenAnswer((_) async => fresh);
+
+      // The very first read (build) shows cached content without a spinner.
+      expect(container.read(homeFeedProvider).value, cachedFeed);
+
+      await container.read(homeFeedProvider.notifier).refresh();
+
+      expect(container.read(homeFeedProvider).value, fresh);
+      expect(cacheOf(container).readHomeFeed(), fresh);
+    });
+
+    test('falls back to the cached feed on a connection error', () async {
+      final cachedFeed = HomeFeed(recentlyAdded: [makeFeedItem()]);
+      final container = createContainer();
+      await cacheOf(container).writeHomeFeed(cachedFeed);
+      when(() => api.getHomeFeed()).thenThrow(connectionError);
+
+      await container.read(homeFeedProvider.notifier).refresh();
+
+      final state = container.read(homeFeedProvider);
+      expect(state.hasError, isFalse);
+      expect(state.value, cachedFeed);
+    });
+  });
+
+  group('channelVideosProvider (family)', () {
+    test('falls back to cached videos on a connection error', () async {
+      final cached = [makeVideo(id: 'v1'), makeVideo(id: 'v2')];
+      final container = createContainer();
+      await cacheOf(container).writeChannelVideos('c1', cached);
+      when(() => api.getChannelVideos('c1')).thenThrow(connectionError);
+
+      await container.read(channelVideosProvider('c1').notifier).refresh();
+
+      final state = container.read(channelVideosProvider('c1'));
+      expect(state.hasError, isFalse);
+      expect(state.value, cached);
+    });
+
+    test('writes through and is scoped per channel', () async {
+      final videos = [makeVideo(id: 'v9')];
+      final container = createContainer();
+      when(() => api.getChannelVideos('c1')).thenAnswer((_) async => videos);
+
+      await container.read(channelVideosProvider('c1').notifier).refresh();
+
+      expect(container.read(channelVideosProvider('c1')).value, videos);
+      expect(cacheOf(container).readChannelVideos('c1'), videos);
+      expect(cacheOf(container).readChannelVideos('c2'), isNull);
+    });
+  });
+}

--- a/test/unit/catalog_cache_service_test.dart
+++ b/test/unit/catalog_cache_service_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:nullfeed/config/constants.dart';
+import 'package:nullfeed/models/feed.dart';
+import 'package:nullfeed/services/catalog_cache_service.dart';
+import 'package:nullfeed/services/storage_service.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  late Directory hiveDir;
+  late StorageService storage;
+  late CatalogCacheService cache;
+
+  setUp(() async {
+    hiveDir = await setUpTestHive();
+    storage = StorageService();
+    await storage.setSelectedUserId('u1');
+    cache = CatalogCacheService(storage: storage);
+  });
+
+  tearDown(() async {
+    await tearDownTestHive(hiveDir);
+  });
+
+  group('channel list', () {
+    test('returns null before anything is written', () {
+      expect(cache.readChannels(), isNull);
+    });
+
+    test('round-trips the channel list through JSON', () async {
+      final channels = [
+        makeChannel(id: 'c1', name: 'Alpha'),
+        makeChannel(id: 'c2', name: 'Beta', avatarUrl: 'https://x/a.jpg'),
+      ];
+
+      await cache.writeChannels(channels);
+
+      expect(cache.readChannels(), channels);
+    });
+  });
+
+  group('home feed', () {
+    test('round-trips the home feed through JSON', () async {
+      expect(cache.readHomeFeed(), isNull);
+
+      final feed = HomeFeed(
+        continueWatching: [makeFeedItem(video: makeVideo(id: 'v1'))],
+        recentlyAdded: [makeFeedItem(video: makeVideo(id: 'v2'))],
+      );
+
+      await cache.writeHomeFeed(feed);
+
+      expect(cache.readHomeFeed(), feed);
+    });
+  });
+
+  group('channel detail and videos', () {
+    test('round-trips a single channel keyed by id', () async {
+      final channel = makeChannel(id: 'c9', name: 'Detail');
+
+      await cache.writeChannel(channel);
+
+      expect(cache.readChannel('c9'), channel);
+      expect(cache.readChannel('other'), isNull);
+    });
+
+    test('round-trips a video list keyed by channel', () async {
+      final videos = [makeVideo(id: 'v1'), makeVideo(id: 'v2')];
+
+      await cache.writeChannelVideos('c1', videos);
+
+      expect(cache.readChannelVideos('c1'), videos);
+      expect(cache.readChannelVideos('c2'), isNull);
+    });
+  });
+
+  group('profile scoping', () {
+    test('one profile never reads another profile\'s cache', () async {
+      await cache.writeChannels([makeChannel(id: 'c1')]);
+      expect(cache.readChannels(), hasLength(1));
+
+      await storage.setSelectedUserId('u2');
+      expect(cache.readChannels(), isNull, reason: 'u2 sees nothing');
+
+      await storage.setSelectedUserId('u1');
+      expect(cache.readChannels(), hasLength(1), reason: 'u1 cache intact');
+    });
+
+    test('reads and writes are no-ops while signed out', () async {
+      await storage.setSelectedUserId(null);
+      await cache.writeChannels([makeChannel()]);
+      expect(cache.readChannels(), isNull);
+
+      await storage.setSelectedUserId('u1');
+      expect(cache.readChannels(), isNull, reason: 'nothing was written');
+    });
+  });
+
+  group('corrupt entries', () {
+    test('a malformed entry reads as null instead of throwing', () async {
+      // Inject a stale-schema / truncated value under our scope's key.
+      await Hive.box(
+        AppConstants.catalogCacheBox,
+      ).put('u1::channels', 'not-json');
+
+      expect(cache.readChannels(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Offline catalog caching (roadmap LATER tier, #13). Previously, launching with the server unreachable showed error/empty states everywhere except already-downloaded files.

## What
- New `CatalogCacheService` persists the last-good **channel list**, **home feed**, and **per-channel video lists** to a Hive box, **keyed by the active profile** (so switching profiles never shows another profile's catalog).
- Providers (`channel_provider`, `feed_provider`, channel detail, home) **hydrate from cache instantly** on launch, then refresh in the background.
- On `ApiException.isConnectionError`, they **fall back to cached data** (`resolveCatalogRefreshError`) instead of surfacing an error; a real (non-connection) server error can still surface. Downloaded videos still play offline.

## Verification
- `dart format` clean · `flutter analyze` — No issues found · `flutter test` — all pass (+ `catalog_cache_service_test` round-trip and `catalog_cache_fallback_test` connection-error fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY