### PR TITLE
feat: Recommended-for-you rail on Home

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,11 +3,15 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/feed.dart';
+import '../models/recommendation.dart';
 import '../providers/feed_provider.dart';
 import '../providers/websocket_provider.dart';
+import '../providers/channel_provider.dart';
+import '../providers/discover_provider.dart';
 import '../services/api_service.dart';
 import '../widgets/content_row.dart';
 import '../widgets/video_card.dart';
+import '../config/constants.dart';
 import '../config/theme.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -111,6 +115,9 @@ class HomeScreen extends ConsumerWidget {
                 ),
               ),
             ),
+            // Surfaces the same AI recommendations as the Discover tab; renders
+            // nothing until there are any, so Home never shows an empty section.
+            const SliverToBoxAdapter(child: _RecommendedForYouRail()),
           ],
         ),
       ),
@@ -204,6 +211,168 @@ class _EmptyHomeState extends StatelessWidget {
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// "Recommended for you" rail — surfaces the same AI recommendations as the
+/// Discover tab ([discoverProvider]) on Home. The WebSocket `recommendation_ready`
+/// event reloads that provider, so this rail refreshes live alongside Discover.
+///
+/// The rail is omitted entirely until there are recommendations to show: pure
+/// loading and error states render nothing here (Home should not carry an empty
+/// or broken suggestion section — the Discover tab owns those states), and a
+/// stale value is kept on screen during a background reload.
+class _RecommendedForYouRail extends ConsumerWidget {
+  const _RecommendedForYouRail();
+
+  /// Subscribes to a recommended channel, mirroring the Discover tab: the
+  /// recommendation is dismissed only after the subscribe succeeds, and
+  /// failures surface via SnackBar.
+  Future<void> _subscribe(
+    BuildContext context,
+    WidgetRef ref,
+    Recommendation rec,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(channelsProvider.notifier)
+          .subscribe(rec.youtubeChannelId!);
+      await ref.read(discoverProvider.notifier).dismiss(rec.id);
+      messenger.showSnackBar(
+        SnackBar(content: Text('Subscribed to ${rec.channelName}')),
+      );
+    } on ApiException catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Could not subscribe: ${e.message}')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recs =
+        ref.watch(discoverProvider).value ?? const <Recommendation>[];
+    if (recs.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ContentRow(
+          title: 'Recommended for you',
+          children: [
+            for (final rec in recs)
+              _RecommendationRailCard(
+                channelName: rec.channelName,
+                reasoning: rec.reasoning,
+                onSubscribe: rec.youtubeChannelId != null
+                    ? () => _subscribe(context, ref, rec)
+                    : null,
+                onDismiss: () =>
+                    ref.read(discoverProvider.notifier).dismiss(rec.id),
+              ),
+          ],
+        ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+/// A compact recommendation card for the Home rail: channel name, the model's
+/// reasoning, and the Discover actions (Subscribe / dismiss). Sized to fit the
+/// fixed [ContentRow] height, so the reasoning is clamped and the Subscribe
+/// button stays pinned to the bottom.
+class _RecommendationRailCard extends StatelessWidget {
+  const _RecommendationRailCard({
+    required this.channelName,
+    required this.reasoning,
+    required this.onDismiss,
+    this.onSubscribe,
+  });
+
+  final String channelName;
+  final String reasoning;
+  final VoidCallback onDismiss;
+  final VoidCallback? onSubscribe;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppConstants.channelCardWidth,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: NullFeedTheme.primaryColor.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Center(
+                      child: Text(
+                        channelName.isNotEmpty
+                            ? channelName[0].toUpperCase()
+                            : '?',
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: NullFeedTheme.primaryColor,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      channelName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 20),
+                    color: NullFeedTheme.textMuted,
+                    visualDensity: VisualDensity.compact,
+                    constraints: const BoxConstraints(
+                      minWidth: 40,
+                      minHeight: 40,
+                    ),
+                    tooltip: 'Dismiss',
+                    onPressed: onDismiss,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Expanded(
+                child: Text(
+                  reasoning,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: onSubscribe,
+                  icon: const Icon(Icons.add, size: 18),
+                  label: const Text('Subscribe'),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -254,8 +254,7 @@ class _RecommendedForYouRail extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final recs =
-        ref.watch(discoverProvider).value ?? const <Recommendation>[];
+    final recs = ref.watch(discoverProvider).value ?? const <Recommendation>[];
     if (recs.isEmpty) return const SizedBox.shrink();
 
     return Column(

--- a/test/widgets/home_screen_recommendations_test.dart
+++ b/test/widgets/home_screen_recommendations_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nullfeed/config/theme.dart';
+import 'package:nullfeed/models/channel.dart';
+import 'package:nullfeed/models/feed.dart';
+import 'package:nullfeed/models/recommendation.dart';
+import 'package:nullfeed/screens/home_screen.dart';
+import 'package:nullfeed/services/api_service.dart';
+import 'package:nullfeed/services/storage_service.dart';
+
+import '../helpers/test_helpers.dart';
+
+Recommendation makeRecommendation({
+  String id = 'r1',
+  String channelName = 'Veritasium',
+  String youtubeChannelId = 'UC-veritasium',
+  String reasoning = 'Because you watch a lot of science explainers.',
+}) {
+  return Recommendation(
+    id: id,
+    channelName: channelName,
+    youtubeChannelId: youtubeChannelId,
+    reasoning: reasoning,
+  );
+}
+
+void main() {
+  late MockApiService api;
+  late FakeStorageService storage;
+
+  setUp(() {
+    api = MockApiService();
+    storage = FakeStorageService();
+    // Home always loads the unified feed; keep it empty so these tests focus on
+    // the recommendations rail. Signed out (no selected profile), the catalog
+    // cache is a no-op, so no Hive setup is needed.
+    when(() => api.getHomeFeed()).thenAnswer((_) async => const HomeFeed());
+  });
+
+  Future<void> pumpHome(WidgetTester tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        apiServiceProvider.overrideWithValue(api),
+        storageServiceProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: NullFeedTheme.darkTheme,
+          home: const HomeScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders the rail with each channel and its reasoning', (
+    tester,
+  ) async {
+    when(() => api.getRecommendations()).thenAnswer(
+      (_) async => [
+        makeRecommendation(
+          channelName: 'Veritasium',
+          reasoning: 'Because you watch science explainers.',
+        ),
+      ],
+    );
+
+    await pumpHome(tester);
+
+    expect(find.text('Recommended for you'), findsOneWidget);
+    expect(find.text('Veritasium'), findsOneWidget);
+    expect(find.text('Because you watch science explainers.'), findsOneWidget);
+    expect(find.text('Subscribe'), findsOneWidget);
+  });
+
+  testWidgets('omits the rail entirely when there are no recommendations', (
+    tester,
+  ) async {
+    when(() => api.getRecommendations()).thenAnswer((_) async => const []);
+
+    await pumpHome(tester);
+
+    expect(find.text('Recommended for you'), findsNothing);
+    expect(find.text('Subscribe'), findsNothing);
+  });
+
+  testWidgets('tapping Subscribe subscribes and dismisses the recommendation', (
+    tester,
+  ) async {
+    when(() => api.getRecommendations()).thenAnswer(
+      (_) async => [
+        makeRecommendation(
+          id: 'r1',
+          channelName: 'Veritasium',
+          youtubeChannelId: 'UC-x',
+        ),
+      ],
+    );
+    when(() => api.getChannels()).thenAnswer((_) async => const <Channel>[]);
+    when(
+      () => api.subscribeToChannel(
+        any(),
+        trackingMode: any(named: 'trackingMode'),
+      ),
+    ).thenAnswer((_) async {});
+    when(() => api.dismissRecommendation(any())).thenAnswer((_) async {});
+
+    await pumpHome(tester);
+
+    // The rail sits below the (tall) empty-feed state, so bring the button into
+    // view before tapping it.
+    await tester.ensureVisible(find.text('Subscribe'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Subscribe'));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => api.subscribeToChannel('UC-x', trackingMode: 'FUTURE_ONLY'),
+    ).called(1);
+    verify(() => api.dismissRecommendation('r1')).called(1);
+    // The subscribe confirmation shows and the card is removed from the rail.
+    expect(find.text('Subscribed to Veritasium'), findsOneWidget);
+    expect(find.text('Recommended for you'), findsNothing);
+
+    // Let the SnackBar's auto-dismiss timer expire before the test ends.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
Surface the existing AI recommendations on the Flutter Home screen (roadmap LATER tier, #18).

## What
- A `_RecommendedForYouRail` sliver on Home (below the feed rows) showing recommendation cards with the model's reasoning.
- **Reuses `discoverProvider`** (the exact provider the Discover tab uses → `ApiService.getRecommendations()`), so no new backend call. The websocket provider already maps `recommendation_ready` → `discoverProvider.load()`, so the Home rail **live-refreshes** alongside Discover with no extra wiring.
- Omitted entirely when there are no recs (no empty/loading section on Home — Discover owns those states).
- Each card has Subscribe + dismiss, mirroring Discover's actual behavior (recommendations are *unsubscribed* channel suggestions with no channel-detail to open until subscribed).

## Verification
- `dart format` clean · `flutter analyze --fatal-infos --fatal-warnings` — No issues · `flutter test` — **126 passed** (+3: rail renders, omitted when empty, Subscribe subscribes+dismisses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY