### PR TITLE
feat: cross-device resume UX (Resume at H:MM / Start over)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,12 +3,44 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'config/app_globals.dart';
 import 'config/theme.dart';
 import 'config/routes.dart';
+import 'providers/auth_provider.dart';
+import 'providers/feed_provider.dart';
 
-class NullFeedApp extends ConsumerWidget {
+class NullFeedApp extends ConsumerStatefulWidget {
   const NullFeedApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NullFeedApp> createState() => _NullFeedAppState();
+}
+
+class _NullFeedAppState extends ConsumerState<NullFeedApp>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // On returning to the foreground, refresh the feed so watch positions
+    // changed elsewhere (notably on another device) surface — the Continue
+    // Watching row in particular. Skipped when signed out: nothing watches the
+    // feed then, and the refetch would just 401.
+    if (state == AppLifecycleState.resumed &&
+        ref.read(authStateProvider).currentUser != null) {
+      invalidateFeedProviders(ref);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final router = ref.watch(routerProvider);
 
     return MaterialApp.router(

--- a/lib/models/video.dart
+++ b/lib/models/video.dart
@@ -47,6 +47,10 @@ abstract class Video with _$Video {
   factory Video.fromJson(Map<String, dynamic> json) => _$VideoFromJson(json);
 }
 
+/// Seconds to rewind when resuming so the viewer gets a moment of context
+/// before the position they left off at.
+const int _resumeRewindSeconds = 10;
+
 extension VideoExtensions on Video {
   bool get isPlayable =>
       status == VideoStatus.complete || previewStatus == 'READY';
@@ -65,6 +69,22 @@ extension VideoExtensions on Video {
   double get watchProgress {
     if (durationSeconds == 0) return 0;
     return watchPositionSeconds / durationSeconds;
+  }
+
+  /// Whether opening this video should resume from [watchPositionSeconds]
+  /// rather than starting over. True only for partially-watched videos: a
+  /// fresh video (position 0) or a fully-watched one ([isWatched]) starts from
+  /// the top. Drives the player's resume affordance.
+  bool get canResume => watchPositionSeconds > 0 && !isWatched;
+
+  /// Where playback should seek when resuming: [watchPositionSeconds] rewound a
+  /// few seconds for context, clamped to the video. Falls back to the raw
+  /// position as the upper bound when the duration is unknown.
+  int get resumeSeekSeconds {
+    final maxSeconds = durationSeconds > 0
+        ? durationSeconds
+        : watchPositionSeconds;
+    return (watchPositionSeconds - _resumeRewindSeconds).clamp(0, maxSeconds);
   }
 
   String get formattedDuration {

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -40,6 +40,13 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   bool _pendingHqSwitch = false;
   bool _progressSavedOnExit = false;
 
+  /// When playback resumed from a saved position, the position (in seconds) the
+  /// viewer left off at — surfaced in the dismissible "Resuming at …" banner so
+  /// they can jump back to the start. Null when starting from the top.
+  int? _resumeFromSeconds;
+  bool _showResumeBanner = false;
+  Timer? _resumeBannerTimer;
+
   /// Set once auto-advance has fired so a stream of post-completion ticks can't
   /// trigger it again.
   bool _advancing = false;
@@ -142,22 +149,25 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     // Prefer the server's resume position (3s budget) but never block
     // playback on the network — fall back to the locally cached position.
     var resumeSeconds = _offline.getWatchPosition(widget.videoId);
+    var fullyWatched = false;
     try {
       final video = await _api
           .getVideo(widget.videoId)
           .timeout(const Duration(seconds: 3));
       _video = video;
       resumeSeconds = video.watchPositionSeconds;
+      fullyWatched = video.isWatched;
     } catch (_) {
       // Offline or slow server — use the local position.
     }
 
-    if (resumeSeconds > 0) {
-      final resumePos = (resumeSeconds - 10).clamp(
-        0,
-        controller.value.duration.inSeconds,
-      );
+    // Resume from the saved spot unless it's been fully watched (then start
+    // over). A rewind gives the viewer a moment of context.
+    if (resumeSeconds > 0 && !fullyWatched) {
+      final resumePos = (resumeSeconds - AppConstants.skipBackwardSeconds)
+          .clamp(0, controller.value.duration.inSeconds);
       await controller.seekTo(Duration(seconds: resumePos));
+      _resumeFromSeconds = resumeSeconds;
     }
 
     await controller.play();
@@ -174,6 +184,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     // Playback has started — keep the screen awake until the player closes.
     unawaited(WakelockPlus.enable());
 
+    _maybeShowResumeBanner();
     _startProgressTimer();
     _scheduleHideControls();
   }
@@ -203,13 +214,11 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
 
     controller.addListener(_onControllerUpdate);
 
-    // Rewind 10s on resume so user can re-orient
-    if (video.watchPositionSeconds > 0) {
-      final resumePos = (video.watchPositionSeconds - 10).clamp(
-        0,
-        video.durationSeconds,
-      );
-      await controller.seekTo(Duration(seconds: resumePos));
+    // Resume from where the viewer left off (rewound a little so they can
+    // re-orient). A fresh or fully-watched video starts from the top.
+    if (video.canResume) {
+      await controller.seekTo(Duration(seconds: video.resumeSeekSeconds));
+      _resumeFromSeconds = video.watchPositionSeconds;
     }
 
     await controller.play();
@@ -236,6 +245,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       unawaited(_switchToHq());
     }
 
+    _maybeShowResumeBanner();
     _startProgressTimer();
     _scheduleHideControls();
   }
@@ -428,6 +438,35 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     if (_showControls) _scheduleHideControls();
   }
 
+  /// Surfaces the dismissible "Resuming at …" banner when playback picked up
+  /// from a saved position. Auto-hides after a few seconds; [_restartFromStart]
+  /// and [_dismissResumeBanner] retire it early.
+  void _maybeShowResumeBanner() {
+    if (_resumeFromSeconds == null) return;
+    setState(() => _showResumeBanner = true);
+    _resumeBannerTimer?.cancel();
+    _resumeBannerTimer = Timer(const Duration(seconds: 8), () {
+      if (mounted) setState(() => _showResumeBanner = false);
+    });
+  }
+
+  /// Abandons the resumed position and plays from the top. Reached from the
+  /// banner's "Start over" action.
+  void _restartFromStart() {
+    _resumeBannerTimer?.cancel();
+    _controller?.seekTo(Duration.zero);
+    setState(() {
+      _showResumeBanner = false;
+      _showControls = true;
+    });
+    _scheduleHideControls();
+  }
+
+  void _dismissResumeBanner() {
+    _resumeBannerTimer?.cancel();
+    setState(() => _showResumeBanner = false);
+  }
+
   void _togglePlayPause() {
     if (_controller == null) return;
     if (_controller!.value.isPlaying) {
@@ -550,6 +589,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _wsSubscription?.cancel();
     _progressTimer?.cancel();
     _hideControlsTimer?.cancel();
+    _resumeBannerTimer?.cancel();
     _previewTimeout?.cancel();
     _previewPollTimer?.cancel();
     _previewMaxWait?.cancel();
@@ -724,8 +764,97 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
                   isQueued: isQueued,
                   onToggleQueue: video == null ? null : _toggleQueue,
                 ),
+
+              // Resume affordance: playback auto-resumed from a saved position
+              // (possibly set on another device) — offer a one-tap jump back to
+              // the start. Sits above the controls so it stays tappable, and
+              // clear of the back button / preview badge at the top corners.
+              if (_showResumeBanner &&
+                  _isInitialized &&
+                  _resumeFromSeconds != null)
+                Positioned(
+                  top: 12,
+                  left: 0,
+                  right: 0,
+                  child: SafeArea(
+                    child: Center(
+                      child: _ResumeBanner(
+                        position: Duration(seconds: _resumeFromSeconds!),
+                        onRestart: _restartFromStart,
+                        onDismiss: _dismissResumeBanner,
+                      ),
+                    ),
+                  ),
+                ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Formats a playback timestamp as M:SS, or H:MM:SS once it crosses an hour.
+String _formatTimestamp(Duration d) {
+  final hours = d.inHours;
+  final minutes = d.inMinutes.remainder(60);
+  final seconds = d.inSeconds.remainder(60);
+  if (hours > 0) {
+    return '$hours:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+  }
+  return '$minutes:${seconds.toString().padLeft(2, '0')}';
+}
+
+/// Brief, dismissible banner shown when playback auto-resumed from a saved
+/// position (which may have been set on another device). Reports where the
+/// viewer left off and offers a one-tap jump back to the start; a close button
+/// dismisses it, and the player also auto-hides it on a timer.
+class _ResumeBanner extends StatelessWidget {
+  final Duration position;
+  final VoidCallback onRestart;
+  final VoidCallback onDismiss;
+
+  const _ResumeBanner({
+    required this.position,
+    required this.onRestart,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        padding: const EdgeInsets.only(left: 16, right: 4),
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.82),
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.history, color: Colors.white70, size: 18),
+            const SizedBox(width: 8),
+            Text(
+              'Resuming at ${_formatTimestamp(position)}',
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+            ),
+            const SizedBox(width: 8),
+            TextButton(
+              onPressed: onRestart,
+              style: TextButton.styleFrom(
+                foregroundColor: NullFeedTheme.primaryColor,
+                minimumSize: const Size(0, 44),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+              ),
+              child: const Text('Start over'),
+            ),
+            IconButton(
+              icon: const Icon(Icons.close, color: Colors.white70, size: 20),
+              tooltip: 'Dismiss',
+              onPressed: onDismiss,
+            ),
+          ],
         ),
       ),
     );
@@ -885,8 +1014,8 @@ class _ControlsOverlay extends StatelessWidget {
                             milliseconds: (fraction * duration.inMilliseconds)
                                 .round(),
                           );
-                          return '${_formatDuration(at)} of '
-                              '${_formatDuration(duration)}';
+                          return '${_formatTimestamp(at)} of '
+                              '${_formatTimestamp(duration)}';
                         },
                         onSeek: (fraction) {
                           final target = Duration(
@@ -902,14 +1031,14 @@ class _ControlsOverlay extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           Text(
-                            _formatDuration(position),
+                            _formatTimestamp(position),
                             style: const TextStyle(
                               color: Colors.white70,
                               fontSize: 12,
                             ),
                           ),
                           Text(
-                            _formatDuration(duration),
+                            _formatTimestamp(duration),
                             style: const TextStyle(
                               color: Colors.white70,
                               fontSize: 12,
@@ -926,16 +1055,6 @@ class _ControlsOverlay extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  String _formatDuration(Duration d) {
-    final hours = d.inHours;
-    final minutes = d.inMinutes.remainder(60);
-    final seconds = d.inSeconds.remainder(60);
-    if (hours > 0) {
-      return '$hours:${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
-    }
-    return '$minutes:${seconds.toString().padLeft(2, '0')}';
   }
 }
 

--- a/test/unit/models_test.dart
+++ b/test/unit/models_test.dart
@@ -206,6 +206,42 @@ void main() {
     });
   });
 
+  group('Video resume', () {
+    Video at(int position, {bool isWatched = false, int duration = 600}) =>
+        Video(
+          id: 'v1',
+          youtubeVideoId: 'yt1',
+          channelId: 'c1',
+          title: 'A Video',
+          durationSeconds: duration,
+          watchPositionSeconds: position,
+          isWatched: isWatched,
+        );
+
+    test('canResume only for a partially-watched video', () {
+      expect(at(0).canResume, isFalse); // fresh — start from the top
+      expect(at(120).canResume, isTrue); // left off mid-video
+      expect(at(120, isWatched: true).canResume, isFalse); // finished — replay
+    });
+
+    test('resumeSeekSeconds rewinds a few seconds for context', () {
+      expect(at(120).resumeSeekSeconds, 110);
+    });
+
+    test('resumeSeekSeconds never goes negative', () {
+      expect(at(5).resumeSeekSeconds, 0);
+    });
+
+    test('resumeSeekSeconds is clamped to the duration', () {
+      expect(at(600, duration: 600).resumeSeekSeconds, 590);
+    });
+
+    test('resumeSeekSeconds falls back to the position when duration is '
+        'unknown', () {
+      expect(at(120, duration: 0).resumeSeekSeconds, 110);
+    });
+  });
+
   group('HomeFeed', () {
     Map<String, dynamic> feedItem(String videoId) => {
       'channel': {


### PR DESCRIPTION
Cross-device resume UX on the player (roadmap LATER tier, #3). Live Continue-Watching updates already worked; this adds the resume affordance.

## What
- A partially-watched video (saved position > 0 **and not fully watched**) opens straight into playback at the saved spot, then a brief top-center pill: **"Resuming at H:MM"** + one-tap **"Start over"** + dismiss; auto-hides after 8s. Fresh / fully-watched videos play from the top with no banner.
- Resume now requires *not fully watched* (was: any position > 0), so a finished video with leftover position restarts instead of resuming near the end. The decision is pure + unit-tested (`Video.canResume` / `resumeSeekSeconds`).
- Position-write paths (periodic 10s, on pause, on exit, dispose) unchanged.
- **Foreground refresh**: `NullFeedApp` observes lifecycle and invalidates the feed providers on `resumed` (auth-gated), so a position changed on another device surfaces in Continue Watching. (A GET refresh, not a content poll — content polling stays on pull-to-refresh per the project rule.) Return-from-player refresh was already wired everywhere.

## Verification
- `dart format --set-exit-if-changed` exit 0 · `flutter analyze` — No issues · `flutter test` — **131 passed** (+5 `canResume`/`resumeSeekSeconds`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY