### PR TITLE
feat: switch stream + WebSocket auth to short-lived tickets (#10)

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -28,6 +28,10 @@ class AppConstants {
   static const String authCreate = '$apiBase/auth/create';
   static const String authMe = '$apiBase/auth/me';
   static const String authLogout = '$apiBase/auth/logout';
+
+  /// Mints a short-lived ticket authorizing a single WebSocket connection, so
+  /// the long-lived session token never appears in the `/ws` URL.
+  static const String wsTicket = '$apiBase/auth/ws-ticket';
   static const String youtubeResolve = '$apiBase/youtube/resolve';
   static const String youtubeSuggestions = '$apiBase/youtube/suggestions';
   static const String channels = '$apiBase/channels';
@@ -54,6 +58,11 @@ class AppConstants {
   static String channelUnsubscribe(String id) =>
       '$apiBase/channels/$id/unsubscribe';
   static String videoDetail(String id) => '$apiBase/videos/$id';
+
+  /// Mints a short-lived ticket authorizing playback of [id], used in place of
+  /// the session token on both [videoStream] and [videoPreviewStream] URLs.
+  static String videoPlaybackTicket(String id) =>
+      '$apiBase/videos/$id/playback-ticket';
   static String videoStream(String id) => '$apiBase/videos/$id/stream';
   static String videoProgress(String id) => '$apiBase/videos/$id/progress';
   static String videoDownload(String id) => '$apiBase/videos/$id/download';

--- a/lib/providers/websocket_provider.dart
+++ b/lib/providers/websocket_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/websocket_service.dart';
 import '../services/storage_service.dart';
 import '../services/offline_service.dart';
+import '../services/api_service.dart';
 import 'auth_provider.dart';
 import 'channel_provider.dart';
 import 'download_progress_provider.dart';
@@ -24,16 +25,20 @@ final webSocketConnectionProvider = Provider<void>((ref) {
     authStateProvider.select((state) => state.currentUser?.id),
   );
   final storage = ref.watch(storageServiceProvider);
+  final apiService = ref.watch(apiServiceProvider);
   final wsService = ref.watch(webSocketServiceProvider);
 
   final serverUrl = storage.getServerUrl();
   final token = storage.getSessionToken();
 
+  // A stored token gates connecting (we must be signed in) but never goes into
+  // the URL — the socket authenticates with a short-lived ticket minted per
+  // connection via [ApiService.getWsTicket].
   if (userId == null || serverUrl == null || token == null) {
     return;
   }
 
-  wsService.connect(serverUrl, userId, token);
+  wsService.connect(serverUrl, userId, apiService.getWsTicket);
 
   final subscription = wsService.events.listen((event) {
     switch (event.type) {

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -100,14 +100,14 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
 
       // Path 1: HQ complete — play directly
       if (video.status == VideoStatus.complete) {
-        final streamUrl = _api.getVideoStreamUrl(widget.videoId);
+        final streamUrl = await _api.getVideoStreamUrl(widget.videoId);
         await _startPlayback(streamUrl, video);
         return;
       }
 
       // Path 2: Preview already ready — play preview, listen for HQ
       if (video.hasPreviewReady) {
-        final previewUrl = _api.getPreviewStreamUrl(widget.videoId);
+        final previewUrl = await _api.getPreviewStreamUrl(widget.videoId);
         await _startPlayback(previewUrl, video, isPreview: true);
         _listenForHqReady();
         return;
@@ -287,19 +287,32 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       },
     );
 
-    _wsSubscription = wsService.events.listen((event) {
+    _wsSubscription = wsService.events.listen((event) async {
       if (event.type == WebSocketEventType.previewReady &&
           event.data['video_id'] == widget.videoId) {
         _stopWaiting();
-        final previewUrl = _api.getPreviewStreamUrl(widget.videoId);
-        _startPlayback(previewUrl, video, isPreview: true);
-        _listenForHqReady();
+        try {
+          final previewUrl = await _api.getPreviewStreamUrl(widget.videoId);
+          if (!mounted) return;
+          // Fire-and-forget so the HQ listener is registered before the preview
+          // finishes initializing — that's what lets an early HQ-ready event be
+          // picked up via _pendingHqSwitch.
+          _startPlayback(previewUrl, video, isPreview: true);
+          _listenForHqReady();
+        } on ApiException catch (e) {
+          if (mounted) setState(() => _error = e.message);
+        }
       } else if (event.type == WebSocketEventType.downloadComplete &&
           event.data['video_id'] == widget.videoId) {
         // HQ finished before preview — play HQ directly
         _stopWaiting();
-        final streamUrl = _api.getVideoStreamUrl(widget.videoId);
-        _startPlayback(streamUrl, video);
+        try {
+          final streamUrl = await _api.getVideoStreamUrl(widget.videoId);
+          if (!mounted) return;
+          _startPlayback(streamUrl, video);
+        } on ApiException catch (e) {
+          if (mounted) setState(() => _error = e.message);
+        }
       }
     });
   }
@@ -317,14 +330,12 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
         if (!mounted || _isInitialized) return;
         if (latest.status == VideoStatus.complete) {
           _stopWaiting();
-          await _startPlayback(_api.getVideoStreamUrl(widget.videoId), latest);
+          final streamUrl = await _api.getVideoStreamUrl(widget.videoId);
+          await _startPlayback(streamUrl, latest);
         } else if (latest.hasPreviewReady) {
           _stopWaiting();
-          await _startPlayback(
-            _api.getPreviewStreamUrl(widget.videoId),
-            latest,
-            isPreview: true,
-          );
+          final previewUrl = await _api.getPreviewStreamUrl(widget.videoId);
+          await _startPlayback(previewUrl, latest, isPreview: true);
           _listenForHqReady();
         }
       } catch (_) {
@@ -370,7 +381,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     final currentSpeed = _controller!.value.playbackSpeed;
 
     try {
-      final streamUrl = _api.getVideoStreamUrl(widget.videoId);
+      final streamUrl = await _api.getVideoStreamUrl(widget.videoId);
       final hqController = VideoPlayerController.networkUrl(
         Uri.parse(streamUrl),
       );

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -79,6 +79,23 @@ class ApiException implements Exception {
   String toString() => message;
 }
 
+/// A short-lived access ticket and the instant it should be treated as stale.
+/// Tickets stand in for the long-lived session token on media and WebSocket
+/// URLs so the token never leaks into them. A small safety margin is folded
+/// into [_staleAt] so a ticket is refreshed shortly before it actually expires
+/// rather than handed out already about to die.
+class _CachedTicket {
+  _CachedTicket(this.value, Duration ttl)
+    : _staleAt = DateTime.now().add(ttl - _refreshMargin);
+
+  static const _refreshMargin = Duration(seconds: 30);
+
+  final String value;
+  final DateTime _staleAt;
+
+  bool get isFresh => DateTime.now().isBefore(_staleAt);
+}
+
 class ApiService {
   final StorageService storage;
 
@@ -90,14 +107,23 @@ class ApiService {
 
   late final Dio _dio;
 
-  ApiService({required this.storage}) {
-    _dio = Dio(
-      BaseOptions(
-        connectTimeout: const Duration(seconds: 10),
-        receiveTimeout: const Duration(seconds: 30),
-        headers: {'Content-Type': 'application/json'},
-      ),
-    );
+  /// Cached short-lived ticket for opening the WebSocket. See [getWsTicket].
+  _CachedTicket? _wsTicket;
+
+  /// Cached playback ticket and the video it authorizes. A request for a
+  /// different video — or a ticket that's gone stale — triggers a refetch.
+  /// See [getPlaybackTicket].
+  String? _playbackTicketVideoId;
+  _CachedTicket? _playbackTicket;
+
+  /// [dio] is injectable so tests can supply a mock HTTP adapter; production
+  /// callers let it default and the interceptors/timeouts below are applied
+  /// either way.
+  ApiService({required this.storage, Dio? dio}) {
+    _dio = dio ?? Dio();
+    _dio.options.connectTimeout = const Duration(seconds: 10);
+    _dio.options.receiveTimeout = const Duration(seconds: 30);
+    _dio.options.headers['Content-Type'] = 'application/json';
     _dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (options, handler) {
@@ -201,6 +227,28 @@ class ApiService {
       options: _withToken(tokenOverride),
     );
   });
+
+  /// Mints (or returns a still-fresh cached) short-lived ticket for opening the
+  /// WebSocket, used in place of the session token in the `/ws` URL. The cache
+  /// keeps reconnects from minting a fresh ticket on every attempt; a stale one
+  /// is refetched automatically. Throws [ApiException] if minting fails.
+  Future<String> getWsTicket() => _guard(() async {
+    final cached = _wsTicket;
+    if (cached != null && cached.isFresh) return cached.value;
+    final response = await _dio.post('$_baseUrl${AppConstants.wsTicket}');
+    final parsed = _parseTicket(response.data);
+    _wsTicket = _CachedTicket(parsed.value, parsed.ttl);
+    return parsed.value;
+  });
+
+  /// Parses a `{ "ticket": ..., "expires_in": <seconds> }` envelope, defaulting
+  /// to a 5-minute TTL when the server omits `expires_in`.
+  ({String value, Duration ttl}) _parseTicket(Object? data) {
+    final map = data as Map<String, dynamic>;
+    final value = map['ticket'] as String;
+    final expiresIn = (map['expires_in'] as num?)?.toInt() ?? 300;
+    return (value: value, ttl: Duration(seconds: expiresIn));
+  }
 
   Future<User> updateProfile(
     String userId, {
@@ -364,10 +412,31 @@ class ApiService {
     return Video.fromJson(response.data as Map<String, dynamic>);
   });
 
-  String getVideoStreamUrl(String id) {
-    final token = storage.getSessionToken();
-    final base = '$_baseUrl${AppConstants.videoStream(id)}';
-    return token != null ? '$base?token=$token' : base;
+  /// Mints (or returns a still-fresh cached) short-lived playback ticket for
+  /// [videoId]. The ticket authorizes both the `/stream` and `/preview-stream`
+  /// URLs, so the long-lived session token never leaks into a media URL.
+  /// Switching to a different video refetches. Throws [ApiException] on
+  /// failure.
+  Future<String> getPlaybackTicket(String videoId) => _guard(() async {
+    final cached = _playbackTicket;
+    if (cached != null && cached.isFresh && _playbackTicketVideoId == videoId) {
+      return cached.value;
+    }
+    final response = await _dio.post(
+      '$_baseUrl${AppConstants.videoPlaybackTicket(videoId)}',
+    );
+    final parsed = _parseTicket(response.data);
+    _playbackTicketVideoId = videoId;
+    _playbackTicket = _CachedTicket(parsed.value, parsed.ttl);
+    return parsed.value;
+  });
+
+  /// Builds the authenticated HQ stream URL for [id], carrying a short-lived
+  /// playback ticket (`?ticket=`) rather than the session token. Throws
+  /// [ApiException] if the ticket can't be minted.
+  Future<String> getVideoStreamUrl(String id) async {
+    final ticket = await getPlaybackTicket(id);
+    return '$_baseUrl${AppConstants.videoStream(id)}?ticket=$ticket';
   }
 
   Future<void> updateProgress(String videoId, int positionSeconds) =>
@@ -398,10 +467,12 @@ class ApiService {
     await _dio.post('$_baseUrl${AppConstants.videoPreview(videoId)}');
   });
 
-  String getPreviewStreamUrl(String id) {
-    final token = storage.getSessionToken();
-    final base = '$_baseUrl${AppConstants.videoPreviewStream(id)}';
-    return token != null ? '$base?token=$token' : base;
+  /// Builds the authenticated 360p preview stream URL for [id]. Like
+  /// [getVideoStreamUrl] it carries a short-lived playback ticket rather than
+  /// the session token. Throws [ApiException] if the ticket can't be minted.
+  Future<String> getPreviewStreamUrl(String id) async {
+    final ticket = await getPlaybackTicket(id);
+    return '$_baseUrl${AppConstants.videoPreviewStream(id)}?ticket=$ticket';
   }
 
   // Search

--- a/lib/services/offline_service.dart
+++ b/lib/services/offline_service.dart
@@ -72,7 +72,6 @@ class OfflineService {
 
     final dir = await _offlineDir;
     final localPath = '$dir/$videoId.mp4';
-    final url = apiService.getVideoStreamUrl(videoId);
 
     await _box.put(videoId, {
       'video_id': videoId,
@@ -90,6 +89,10 @@ class OfflineService {
     onListChanged?.call();
 
     try {
+      // Mint the ticketed stream URL here (not before the entry is written) so
+      // a failed ticket mint marks the download failed via the catch below
+      // rather than escaping the method and stranding the in-flight guard.
+      final url = await apiService.getVideoStreamUrl(videoId);
       await _dio.download(
         url,
         localPath,
@@ -124,6 +127,10 @@ class OfflineService {
       } else {
         _updateEntry(videoId, {'status': 'failed'});
       }
+    } catch (_) {
+      // Couldn't mint a playback ticket (or any other unexpected error) — mark
+      // the entry failed so the UI can offer a retry.
+      _updateEntry(videoId, {'status': 'failed'});
     } finally {
       _cancelTokens.remove(videoId);
       onProgress?.call(videoId, null);

--- a/lib/services/websocket_service.dart
+++ b/lib/services/websocket_service.dart
@@ -38,6 +38,11 @@ class WebSocketEvent {
 /// Creates a [WebSocketChannel] for [uri]. Injectable for tests.
 typedef WebSocketChannelFactory = WebSocketChannel Function(Uri uri);
 
+/// Mints a fresh, short-lived ticket authorizing one WebSocket connection.
+/// Called on every (re)connect so the socket carries a ticket — never the
+/// long-lived session token — and a stale ticket is refreshed transparently.
+typedef WsTicketFetcher = Future<String> Function();
+
 class WebSocketService {
   WebSocketService({WebSocketChannelFactory? channelFactory})
     : _channelFactory = channelFactory ?? WebSocketChannel.connect;
@@ -52,16 +57,29 @@ class WebSocketService {
   WebSocketChannel? _channel;
   StreamSubscription<dynamic>? _subscription;
   Timer? _reconnectTimer;
-  Uri? _uri;
+
+  /// Socket URL without the auth query; the ticket is appended fresh on every
+  /// [_open] so an expired ticket never sticks. Null when there's no target.
+  String? _wsUrl;
+  WsTicketFetcher? _ticketFetcher;
+
   bool _intentionalClose = false;
   bool _disposed = false;
   int _retryCount = 0;
 
+  /// Bumped by every [connect]/[disconnect] so an in-flight async [_open] from
+  /// a superseded connection notices it's stale and bails instead of clobbering
+  /// the current channel after its ticket fetch resolves.
+  int _generation = 0;
+
   Stream<WebSocketEvent> get events => _eventController.stream;
   bool get isConnected => _channel != null;
 
-  /// Opens (or re-opens) the socket for [userId], authenticating with [token].
-  void connect(String serverUrl, String userId, String token) {
+  /// Opens (or re-opens) the socket for [userId]. [ticketFetcher] mints a
+  /// short-lived access ticket; it's invoked on every connect and reconnect so
+  /// the long-lived session token never appears in the URL and an expired
+  /// ticket is refreshed automatically.
+  void connect(String serverUrl, String userId, WsTicketFetcher ticketFetcher) {
     if (_disposed) return;
     disconnect();
     _intentionalClose = false;
@@ -69,15 +87,36 @@ class WebSocketService {
     final host = serverUrl
         .replaceFirst('https://', '')
         .replaceFirst('http://', '');
-    _uri = Uri.parse('$wsScheme://$host/ws/$userId?token=$token');
+    _wsUrl = '$wsScheme://$host/ws/$userId';
+    _ticketFetcher = ticketFetcher;
     _retryCount = 0;
     _open();
   }
 
-  void _open() {
-    if (_disposed || _intentionalClose || _uri == null) return;
+  Future<void> _open() async {
+    if (_disposed || _intentionalClose) return;
+    final wsUrl = _wsUrl;
+    final fetcher = _ticketFetcher;
+    if (wsUrl == null || fetcher == null) return;
+
+    // Capture the generation before the async gap so a connect()/disconnect()
+    // that lands while we await the ticket can be detected below.
+    final generation = _generation;
+    final String ticket;
     try {
-      final channel = _channelFactory(_uri!);
+      ticket = await fetcher();
+    } catch (_) {
+      // Couldn't mint a ticket (offline, or the session is gone). Retry with
+      // backoff rather than hanging; a genuinely dead session is torn down by
+      // the global 401 handler when other requests fail.
+      if (generation == _generation) _scheduleReconnect();
+      return;
+    }
+    // A newer connect()/disconnect() superseded this attempt mid-fetch.
+    if (generation != _generation || _disposed || _intentionalClose) return;
+
+    try {
+      final channel = _channelFactory(Uri.parse('$wsUrl?ticket=$ticket'));
       _channel = channel;
       _subscription = channel.stream.listen(
         (message) {
@@ -94,8 +133,10 @@ class WebSocketService {
         },
         onError: (Object _) => _scheduleReconnect(),
         onDone: () {
-          // 4401 = server rejected the token; retrying with the same
-          // credentials can never succeed. Wait for the next connect().
+          // 4401 = server rejected the ticket at the handshake. We just minted
+          // a fresh one, so a reject means the underlying session is dead, not
+          // a stale ticket — reconnecting can't help. Wait for the next
+          // connect() (which the global 401 sign-out flow triggers).
           if (_channel?.closeCode == 4401) {
             disconnect();
             return;
@@ -132,13 +173,16 @@ class WebSocketService {
   /// next explicit [connect] call.
   void disconnect() {
     _intentionalClose = true;
+    // Invalidate any in-flight _open() still awaiting a ticket.
+    _generation++;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     _subscription?.cancel();
     _subscription = null;
     _channel?.sink.close();
     _channel = null;
-    _uri = null;
+    _wsUrl = null;
+    _ticketFetcher = null;
     _retryCount = 0;
   }
 

--- a/test/unit/api_service_test.dart
+++ b/test/unit/api_service_test.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/config/constants.dart';
+import 'package:nullfeed/services/api_service.dart';
+
+import '../helpers/test_helpers.dart';
+
+/// Minimal [HttpClientAdapter] that records every request and returns a canned
+/// response built by [handler]. Lets us drive [ApiService] without real HTTP.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this.handler);
+
+  final ResponseBody Function(RequestOptions options) handler;
+  final List<RequestOptions> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    return handler(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _json(Map<String, dynamic> body, {int status = 200}) =>
+    ResponseBody.fromString(
+      jsonEncode(body),
+      status,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+
+void main() {
+  late FakeStorageService storage;
+
+  setUp(() {
+    storage = FakeStorageService(serverUrl: 'http://server:8484');
+  });
+
+  ApiService apiWith(_FakeAdapter adapter) {
+    final dio = Dio()..httpClientAdapter = adapter;
+    return ApiService(storage: storage, dio: dio);
+  }
+
+  int postsTo(_FakeAdapter adapter, bool Function(String path) match) =>
+      adapter.requests.where((r) => match(r.uri.path)).length;
+
+  group('getPlaybackTicket', () {
+    test('POSTs the playback-ticket endpoint and returns the ticket', () async {
+      final adapter = _FakeAdapter(
+        (_) => _json({'ticket': 'pt-1', 'expires_in': 300}),
+      );
+      final api = apiWith(adapter);
+
+      final ticket = await api.getPlaybackTicket('vid-1');
+
+      expect(ticket, 'pt-1');
+      expect(adapter.requests.single.method, 'POST');
+      expect(
+        adapter.requests.single.uri.toString(),
+        'http://server:8484${AppConstants.videoPlaybackTicket('vid-1')}',
+      );
+    });
+
+    test('caches per video and refetches only for a new video', () async {
+      var n = 0;
+      final adapter = _FakeAdapter(
+        (_) => _json({'ticket': 'pt-${++n}', 'expires_in': 300}),
+      );
+      final api = apiWith(adapter);
+
+      expect(await api.getPlaybackTicket('vid-1'), 'pt-1');
+      expect(
+        await api.getPlaybackTicket('vid-1'),
+        'pt-1',
+        reason: 'same video reuses the cached ticket',
+      );
+      expect(postsTo(adapter, (p) => p.endsWith('/playback-ticket')), 1);
+
+      expect(
+        await api.getPlaybackTicket('vid-2'),
+        'pt-2',
+        reason: 'a different video refetches',
+      );
+      expect(postsTo(adapter, (p) => p.endsWith('/playback-ticket')), 2);
+    });
+
+    test('refetches once a cached ticket nears expiry', () async {
+      var n = 0;
+      // 20s TTL minus the 30s refresh margin => already stale, so each call
+      // mints afresh.
+      final adapter = _FakeAdapter(
+        (_) => _json({'ticket': 'pt-${++n}', 'expires_in': 20}),
+      );
+      final api = apiWith(adapter);
+
+      expect(await api.getPlaybackTicket('vid-1'), 'pt-1');
+      expect(
+        await api.getPlaybackTicket('vid-1'),
+        'pt-2',
+        reason: 'a near-expired ticket is not reused',
+      );
+    });
+  });
+
+  group('stream URLs', () {
+    test(
+      'getVideoStreamUrl carries a ticket, never the session token',
+      () async {
+        await storage.setSessionToken('sess-token');
+        final adapter = _FakeAdapter(
+          (_) => _json({'ticket': 'pt-9', 'expires_in': 300}),
+        );
+        final api = apiWith(adapter);
+
+        final url = await api.getVideoStreamUrl('vid-7');
+
+        expect(
+          url,
+          'http://server:8484${AppConstants.videoStream('vid-7')}?ticket=pt-9',
+        );
+        expect(url, isNot(contains('token=')));
+        expect(url, isNot(contains('sess-token')));
+      },
+    );
+
+    test('stream and preview URLs share one playback ticket', () async {
+      var n = 0;
+      final adapter = _FakeAdapter(
+        (_) => _json({'ticket': 'pt-${++n}', 'expires_in': 300}),
+      );
+      final api = apiWith(adapter);
+
+      final streamUrl = await api.getVideoStreamUrl('vid-3');
+      final previewUrl = await api.getPreviewStreamUrl('vid-3');
+
+      expect(
+        streamUrl,
+        endsWith('${AppConstants.videoStream('vid-3')}?ticket=pt-1'),
+      );
+      expect(
+        previewUrl,
+        endsWith('${AppConstants.videoPreviewStream('vid-3')}?ticket=pt-1'),
+      );
+      expect(
+        postsTo(adapter, (p) => p.endsWith('/playback-ticket')),
+        1,
+        reason: 'one ticket authorizes both stream and preview',
+      );
+    });
+
+    test('surfaces an ApiException when the ticket mint fails', () async {
+      final adapter = _FakeAdapter(
+        (_) => _json({'code': 'unauthorized', 'detail': 'nope'}, status: 401),
+      );
+      final api = apiWith(adapter);
+
+      await expectLater(
+        api.getVideoStreamUrl('vid-x'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+
+  group('getWsTicket', () {
+    test('POSTs the ws-ticket endpoint and caches the result', () async {
+      var n = 0;
+      final adapter = _FakeAdapter(
+        (_) => _json({'ticket': 'wt-${++n}', 'expires_in': 300}),
+      );
+      final api = apiWith(adapter);
+
+      expect(await api.getWsTicket(), 'wt-1');
+      expect(
+        await api.getWsTicket(),
+        'wt-1',
+        reason: 'cached until it nears expiry',
+      );
+      expect(postsTo(adapter, (p) => p == AppConstants.wsTicket), 1);
+    });
+  });
+}

--- a/test/unit/websocket_service_test.dart
+++ b/test/unit/websocket_service_test.dart
@@ -57,6 +57,23 @@ class _ChannelFactory {
   }
 }
 
+/// A [WsTicketFetcher] that records its call count and hands out a fresh ticket
+/// each time (`tkt-1`, `tkt-2`, …), so tests can prove a new ticket is minted
+/// on every (re)connect. Optionally throws once to simulate a mint failure.
+class _TicketFetcher {
+  int calls = 0;
+  bool throwOnce = false;
+
+  Future<String> call() async {
+    calls++;
+    if (throwOnce) {
+      throwOnce = false;
+      throw Exception('ticket mint failed');
+    }
+    return 'tkt-$calls';
+  }
+}
+
 Map<String, dynamic> _progressEvent(String videoId) => {
   'type': 'download_progress',
   'data': {'video_id': videoId, 'percentage': 42},
@@ -101,36 +118,45 @@ void main() {
   });
 
   group('connect', () {
-    test('builds a ws URI with the user id and token appended', () {
-      service.connect('http://192.168.1.50:8484', 'user-1', 'tok123');
+    test('builds a ws URI with the user id and ticket appended', () async {
+      service.connect(
+        'http://192.168.1.50:8484',
+        'user-1',
+        () async => 'tok123',
+      );
+      await pumpEventQueue();
 
       expect(
         factory.uris.single.toString(),
-        'ws://192.168.1.50:8484/ws/user-1?token=tok123',
+        'ws://192.168.1.50:8484/ws/user-1?ticket=tok123',
       );
       expect(service.isConnected, isTrue);
 
       service.dispose();
     });
 
-    test('uses wss for https servers', () {
-      service.connect('https://nullfeed.example.com', 'u1', 't');
+    test('uses wss for https servers', () async {
+      service.connect('https://nullfeed.example.com', 'u1', () async => 't');
+      await pumpEventQueue();
 
       expect(
         factory.uris.single.toString(),
-        'wss://nullfeed.example.com/ws/u1?token=t',
+        'wss://nullfeed.example.com/ws/u1?ticket=t',
       );
 
       service.dispose();
     });
 
-    test('connecting again closes the previous channel', () {
-      service.connect('http://h1', 'u1', 't1');
-      service.connect('http://h2', 'u1', 't2');
+    test('connecting again closes the previous channel', () async {
+      service.connect('http://h1', 'u1', () async => 't1');
+      await pumpEventQueue();
+      service.connect('http://h2', 'u1', () async => 't2');
+      await pumpEventQueue();
 
       expect(factory.channels, hasLength(2));
       expect(factory.channels.first.sinkClosed, isTrue);
       expect(factory.uris.last.host, 'h2');
+      expect(factory.uris.last.toString(), endsWith('?ticket=t2'));
 
       service.dispose();
     });
@@ -140,7 +166,8 @@ void main() {
     test('parses incoming messages and skips malformed ones', () async {
       final events = <WebSocketEvent>[];
       final subscription = service.events.listen(events.add);
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await pumpEventQueue();
 
       final channel = factory.channels.single;
       channel.emit(_progressEvent('v1'));
@@ -170,7 +197,8 @@ void main() {
 
   group('reconnect state machine', () {
     testWidgets('reconnects after the connection drops', (tester) async {
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       expect(factory.channels, hasLength(1));
 
       factory.channels.single.drop();
@@ -179,23 +207,26 @@ void main() {
 
       // First retry delay is 1s plus up to 250ms of jitter.
       await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
       expect(factory.channels, hasLength(2));
 
       service.dispose();
     });
 
     testWidgets('does not reconnect after a 4401 auth reject', (tester) async {
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       expect(factory.channels, hasLength(1));
 
-      // Server closes with the auth-reject code: same token can never work.
+      // Server closes with the auth-reject code: a fresh ticket can't help.
       factory.channels.single.drop(code: 4401);
       await tester.pump();
       await tester.pump(const Duration(seconds: 35));
       expect(factory.channels, hasLength(1));
 
-      // An explicit reconnect (e.g. with a fresh token) still works.
-      service.connect('http://h', 'u1', 't2');
+      // An explicit reconnect (e.g. after re-signing-in) still works.
+      service.connect('http://h', 'u1', () async => 't2');
+      await tester.pump();
       expect(factory.channels, hasLength(2));
 
       service.dispose();
@@ -212,10 +243,12 @@ void main() {
         },
       );
 
-      throwingService.connect('http://h', 'u1', 't');
+      throwingService.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       expect(calls, 1);
 
       await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
       expect(calls, 2);
 
       throwingService.dispose();
@@ -224,20 +257,24 @@ void main() {
     testWidgets('backoff grows and resets after a successful message', (
       tester,
     ) async {
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
 
       // Failure #1: retry within [1000ms, 1250ms].
       factory.channels.last.drop();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
       expect(factory.channels, hasLength(2));
 
       // Failure #2: retry within [2000ms, 2500ms] — NOT within 1300ms.
       factory.channels.last.drop();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
       expect(factory.channels, hasLength(2), reason: 'backoff has grown');
       await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
       expect(factory.channels, hasLength(3));
 
       // A successful message resets the backoff to the base delay.
@@ -246,6 +283,7 @@ void main() {
       factory.channels.last.drop();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
       expect(
         factory.channels,
         hasLength(4),
@@ -256,7 +294,8 @@ void main() {
     });
 
     testWidgets('never reconnects after disconnect()', (tester) async {
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       service.disconnect();
       expect(service.isConnected, isFalse);
       expect(factory.channels.single.sinkClosed, isTrue);
@@ -267,7 +306,8 @@ void main() {
     });
 
     testWidgets('disconnect() cancels a pending retry', (tester) async {
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       factory.channels.single.drop();
       await tester.pump();
 
@@ -277,7 +317,8 @@ void main() {
     });
 
     testWidgets('never reconnects after dispose()', (tester) async {
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       factory.channels.single.drop();
       await tester.pump();
 
@@ -292,9 +333,11 @@ void main() {
       final events = <WebSocketEvent>[];
       service.events.listen(events.add);
 
-      service.connect('http://h', 'u1', 't');
+      service.connect('http://h', 'u1', () async => 't');
+      await tester.pump();
       service.disconnect();
-      service.connect('http://h', 'u1', 't2');
+      service.connect('http://h', 'u1', () async => 't2');
+      await tester.pump();
 
       expect(factory.channels, hasLength(2));
       factory.channels.last.emit(_progressEvent('v2'));
@@ -303,6 +346,70 @@ void main() {
       expect(events.single.data['video_id'], 'v2');
 
       service.dispose();
+    });
+  });
+
+  group('tickets', () {
+    testWidgets('mints a fresh ticket for each (re)connect', (tester) async {
+      final fetcher = _TicketFetcher();
+      service.connect('http://h', 'u1', fetcher.call);
+      await tester.pump();
+      expect(fetcher.calls, 1);
+      expect(factory.uris.single.toString(), endsWith('?ticket=tkt-1'));
+
+      // A drop-triggered reconnect mints a brand-new ticket rather than reusing
+      // the stale one baked into the previous URL.
+      factory.channels.single.drop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
+      expect(fetcher.calls, 2);
+      expect(factory.uris.last.toString(), endsWith('?ticket=tkt-2'));
+
+      service.dispose();
+    });
+
+    testWidgets('schedules a reconnect when the ticket fetch fails', (
+      tester,
+    ) async {
+      final fetcher = _TicketFetcher()..throwOnce = true;
+      service.connect('http://h', 'u1', fetcher.call);
+      await tester.pump();
+
+      // The first mint threw, so there's no channel yet — but the service must
+      // not hang or give up; it backs off and tries again.
+      expect(fetcher.calls, 1);
+      expect(factory.channels, isEmpty);
+      expect(service.isConnected, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 1300));
+      await tester.pump();
+      expect(fetcher.calls, 2);
+      expect(factory.channels, hasLength(1));
+      expect(factory.uris.single.toString(), endsWith('?ticket=tkt-2'));
+
+      service.dispose();
+    });
+
+    testWidgets('a ticket resolving after disconnect() never connects', (
+      tester,
+    ) async {
+      // Hold the ticket future open so we can disconnect mid-fetch.
+      final completer = Completer<String>();
+      service.connect('http://h', 'u1', () => completer.future);
+      await tester.pump();
+      expect(factory.channels, isEmpty, reason: 'still awaiting the ticket');
+
+      service.disconnect();
+      completer.complete('late-ticket');
+      await tester.pump();
+
+      expect(
+        factory.channels,
+        isEmpty,
+        reason: 'a superseded open must not open a channel',
+      );
+      expect(service.isConnected, isFalse);
     });
   });
 }


### PR DESCRIPTION
Stop leaking the session token in media/WS URLs — switch to the backend's short-lived tickets (roadmap LATER tier, #10). The backend still accepts `?token=`, so this is a clean switch, not a hard break.

## What
- `ApiService.getPlaybackTicket(videoId)` (`POST /api/videos/{id}/playback-ticket`) + `getWsTicket()` (`POST /api/auth/ws-ticket`). `getVideoStreamUrl`/`getPreviewStreamUrl` are now `Future<String>` and append `?ticket=` (no more `?token=`); one playback ticket covers both `/stream` and `/preview-stream` for a video.
- WebSocket `connect()` takes a ticket fetcher and mints a fresh ws ticket each (re)connect (`?ticket=`); a generation guard drops a stale in-flight open.
- Ticket caching keyed by video, TTL = server `expires_in` − 30s margin (backed by the 12h stream TTL, so long videos play through). Mint failure surfaces the player error / marks an offline download failed / backs the WS off — no hang. `grep token=` over `lib/` is clean.

## Verification
- `dart format --set-exit-if-changed` exit 0 · `flutter analyze --fatal-infos --fatal-warnings` — No issues · `flutter test` — **141 passed** (+25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY