### PR TITLE
feat(player): instant-start cold presses via the progressive proxy

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -75,6 +75,8 @@ class AppConstants {
   static String videoPlaybackTicket(String id) =>
       '$apiBase/videos/$id/playback-ticket';
   static String videoStream(String id) => '$apiBase/videos/$id/stream';
+  static String videoInstantStream(String id) =>
+      '$apiBase/videos/$id/instant-stream';
   static String videoProgress(String id) => '$apiBase/videos/$id/progress';
   static String videoDownload(String id) => '$apiBase/videos/$id/download';
   static String videoCancel(String id) => '$apiBase/videos/$id/cancel';

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -113,7 +113,26 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
         return;
       }
 
-      // Path 3: No preview yet — request one, show spinner, listen for it
+      // Path 3: Not downloaded yet — start instantly by proxying a progressive
+      // source stream, then listen for an HQ download to swap in if one lands.
+      // This replaces waiting for a preview file to be generated on a cold
+      // press; the preview path below stays as a fallback.
+      try {
+        final instantUrl = await _api.getInstantStreamUrl(widget.videoId);
+        if (await _startPlayback(
+          instantUrl,
+          video,
+          isPreview: true,
+          reportErrors: false,
+        )) {
+          _listenForHqReady();
+          return;
+        }
+      } on ApiException {
+        // Couldn't mint a ticket / reach the server — fall back to a preview.
+      }
+
+      // Fallback: request a preview, show spinner, and listen for it.
       try {
         await _api.requestPreview(widget.videoId);
       } catch (_) {
@@ -189,14 +208,19 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _scheduleHideControls();
   }
 
-  Future<void> _startPlayback(
+  /// Starts playback from [url]. Returns true once playback has started, false
+  /// if it was superseded (a start race lost) or the source failed to load.
+  /// When [reportErrors] is false a failure is returned silently without
+  /// surfacing an error screen, so the caller can fall back to another source.
+  Future<bool> _startPlayback(
     String url,
     Video video, {
     bool isPreview = false,
+    bool reportErrors = true,
   }) async {
     // A WS event and a poll tick can race to start playback; only the first
     // caller proceeds (checked-and-set synchronously, before any await).
-    if (_startingPlayback || _isInitialized) return;
+    if (_startingPlayback || _isInitialized) return false;
     _startingPlayback = true;
 
     final controller = VideoPlayerController.networkUrl(Uri.parse(url));
@@ -206,10 +230,10 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     } catch (e) {
       controller.dispose();
       _startingPlayback = false;
-      if (mounted) {
+      if (mounted && reportErrors) {
         setState(() => _error = 'Failed to load video: $e');
       }
-      return;
+      return false;
     }
 
     controller.addListener(_onControllerUpdate);
@@ -226,7 +250,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     if (!mounted) {
       controller.dispose();
       _startingPlayback = false;
-      return;
+      return false;
     }
 
     setState(() {
@@ -248,6 +272,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _maybeShowResumeBanner();
     _startProgressTimer();
     _scheduleHideControls();
+    return true;
   }
 
   void _startProgressTimer() {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -439,6 +439,15 @@ class ApiService {
     return '$_baseUrl${AppConstants.videoStream(id)}?ticket=$ticket';
   }
 
+  /// Builds the authenticated instant-start stream URL for [id]. The backend
+  /// resolves and reverse-proxies a progressive source so a not-yet-downloaded
+  /// video plays immediately; like [getVideoStreamUrl] it carries a short-lived
+  /// playback ticket. Throws [ApiException] if the ticket can't be minted.
+  Future<String> getInstantStreamUrl(String id) async {
+    final ticket = await getPlaybackTicket(id);
+    return '$_baseUrl${AppConstants.videoInstantStream(id)}?ticket=$ticket';
+  }
+
   Future<void> updateProgress(String videoId, int positionSeconds) =>
       _guard(() async {
         await _dio.put(

--- a/test/unit/api_service_test.dart
+++ b/test/unit/api_service_test.dart
@@ -133,30 +133,38 @@ void main() {
       },
     );
 
-    test('stream and preview URLs share one playback ticket', () async {
-      var n = 0;
-      final adapter = _FakeAdapter(
-        (_) => _json({'ticket': 'pt-${++n}', 'expires_in': 300}),
-      );
-      final api = apiWith(adapter);
+    test(
+      'stream, instant, and preview URLs share one playback ticket',
+      () async {
+        var n = 0;
+        final adapter = _FakeAdapter(
+          (_) => _json({'ticket': 'pt-${++n}', 'expires_in': 300}),
+        );
+        final api = apiWith(adapter);
 
-      final streamUrl = await api.getVideoStreamUrl('vid-3');
-      final previewUrl = await api.getPreviewStreamUrl('vid-3');
+        final streamUrl = await api.getVideoStreamUrl('vid-3');
+        final instantUrl = await api.getInstantStreamUrl('vid-3');
+        final previewUrl = await api.getPreviewStreamUrl('vid-3');
 
-      expect(
-        streamUrl,
-        endsWith('${AppConstants.videoStream('vid-3')}?ticket=pt-1'),
-      );
-      expect(
-        previewUrl,
-        endsWith('${AppConstants.videoPreviewStream('vid-3')}?ticket=pt-1'),
-      );
-      expect(
-        postsTo(adapter, (p) => p.endsWith('/playback-ticket')),
-        1,
-        reason: 'one ticket authorizes both stream and preview',
-      );
-    });
+        expect(
+          streamUrl,
+          endsWith('${AppConstants.videoStream('vid-3')}?ticket=pt-1'),
+        );
+        expect(
+          instantUrl,
+          endsWith('${AppConstants.videoInstantStream('vid-3')}?ticket=pt-1'),
+        );
+        expect(
+          previewUrl,
+          endsWith('${AppConstants.videoPreviewStream('vid-3')}?ticket=pt-1'),
+        );
+        expect(
+          postsTo(adapter, (p) => p.endsWith('/playback-ticket')),
+          1,
+          reason: 'one ticket authorizes stream, instant, and preview',
+        );
+      },
+    );
 
     test('surfaces an ApiException when the ticket mint fails', () async {
       final adapter = _FakeAdapter(


### PR DESCRIPTION
## What

A cold press on a **not-yet-downloaded** video used to request a 360p preview and **spin until the backend finished generating it**. This switches that path to the backend's new `/instant-stream` endpoint so playback starts immediately.

Depends on the backend endpoint in windoze95/nullfeed-backend#85.

## Changes

- **`api_service.dart`**: `getInstantStreamUrl(id)` — builds the instant-stream URL, sharing the same short-lived playback ticket as the HQ/preview stream URLs. **`constants.dart`**: `videoInstantStream`.
- **`video_player_screen.dart`**: the cold path (`_initPlayer` Path 3) now plays the instant stream and registers the HQ-swap listener. The preview request/wait path stays as a **fallback** if the instant stream can't be started (so no behavior is lost, and no dead code). `_startPlayback` now returns whether playback started, so the cold path can fall back silently (`reportErrors: false`).
- **`api_service_test.dart`**: asserts the instant URL shares the one playback ticket.

The HQ download and the **seamless in-player quality swap are unchanged** — `_listenForHqReady` / `_switchToHq` still upgrade to HQ when a download completes.

## Verification

- `dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` → No issues, `flutter test` → **151 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)