### PR TITLE
feat(player): cache HQ on cold-press so the preview→HQ swap fires

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -80,6 +80,7 @@ class AppConstants {
   static String videoProgress(String id) => '$apiBase/videos/$id/progress';
   static String videoDownload(String id) => '$apiBase/videos/$id/download';
   static String videoCancel(String id) => '$apiBase/videos/$id/cancel';
+  static String videoCache(String id) => '$apiBase/videos/$id/cache';
   static String videoPreview(String id) => '$apiBase/videos/$id/preview';
   static String videoPreviewStream(String id) =>
       '$apiBase/videos/$id/preview-stream';

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -125,6 +125,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
           isPreview: true,
           reportErrors: false,
         )) {
+          // Cache the HQ version in the background (evictable, not a library
+          // download) so the player can swap preview -> HQ. Best-effort.
+          unawaited(_api.cacheVideo(widget.videoId).catchError((_) {}));
           _listenForHqReady();
           return;
         }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -472,6 +472,14 @@ class ApiService {
     await _dio.post('$_baseUrl${AppConstants.videoCancel(videoId)}');
   });
 
+  /// Records an evictable cache claim on [videoId] and (server-side) kicks off
+  /// its HQ download, without it showing in the Downloads tab. Called when the
+  /// user starts instant playback of a not-yet-downloaded video so the player
+  /// can swap up to HQ. Best-effort and idempotent.
+  Future<void> cacheVideo(String videoId) => _guard(() async {
+    await _dio.post('$_baseUrl${AppConstants.videoCache(videoId)}');
+  });
+
   Future<void> requestPreview(String videoId) => _guard(() async {
     await _dio.post('$_baseUrl${AppConstants.videoPreview(videoId)}');
   });

--- a/test/unit/api_service_test.dart
+++ b/test/unit/api_service_test.dart
@@ -179,6 +179,19 @@ void main() {
     });
   });
 
+  group('cacheVideo', () {
+    test('POSTs the cache endpoint', () async {
+      final adapter = _FakeAdapter((_) => _json({'status': 'PENDING'}));
+      final api = apiWith(adapter);
+
+      await api.cacheVideo('vid-9');
+
+      final req = adapter.requests.single;
+      expect(req.method, 'POST');
+      expect(req.uri.path, AppConstants.videoCache('vid-9'));
+    });
+  });
+
   group('getWsTicket', () {
     test('POSTs the ws-ticket endpoint and caches the result', () async {
       var n = 0;


### PR DESCRIPTION
## What

Builds on the instant-start PR (#46). When the cold path starts the instant (progressive) stream, it now also calls **`POST /{id}/cache`** so the backend records an evictable cache claim and downloads HQ in the background. The existing `_listenForHqReady` / `_switchToHq` then upgrades preview → HQ.

Depends on backend windoze95/nullfeed-backend#86 (the `/cache` endpoint + cache-ref model).

> **Stacked on `feature/instant-stream`** (base branch), so this PR's diff is only the track-2 delta. Will retarget to `main` after #46 merges.

## Changes

- `api_service.dart`: `cacheVideo(id)` → `POST /api/videos/{id}/cache`. `constants.dart`: `videoCache`.
- `video_player_screen.dart`: on cold-press, after instant playback starts, fire-and-forget `cacheVideo` (best-effort). The download is evictable (a cache, not a library entry) and hidden from the Downloads tab.

## Verification

`dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` → No issues, `flutter test` → **152 passed** (+1 cacheVideo test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)