### PR TITLE
feat(prewarm): pre-generate previews for channel + queue videos

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -46,6 +46,7 @@ class AppConstants {
   static const String channelPollAll = '$apiBase/channels/poll';
   static const String videos = '$apiBase/videos';
   static const String activeDownloads = '$apiBase/videos/downloads';
+  static const String videosPrewarm = '$apiBase/videos/prewarm';
   static const String queue = '$apiBase/queue';
   static const String feedHome = '$apiBase/feed/home';
   static const String feedContinueWatching = '$apiBase/feed/continue-watching';
@@ -97,6 +98,9 @@ class AppConstants {
   /// showing a graceful "taking longer than expected" message instead of an
   /// indefinite spinner.
   static const int previewMaxWaitSeconds = 180;
+
+  /// Max videos one /prewarm call asks the backend to pre-generate previews for.
+  static const int prewarmBatchSize = 12;
 
   // UI
   static const double cardAspectRatio = 16 / 9;

--- a/lib/providers/channel_provider.dart
+++ b/lib/providers/channel_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../config/constants.dart';
 import '../models/channel.dart';
 import '../models/video.dart';
 import '../services/api_service.dart';
@@ -145,6 +146,7 @@ class ChannelVideosNotifier extends Notifier<AsyncValue<List<Video>>> {
       final videos = await api.getChannelVideos(_channelId);
       await cache.writeChannelVideos(_channelId, videos);
       if (ref.mounted) state = AsyncValue.data(videos);
+      _prewarm(videos);
     } catch (e, st) {
       if (ref.mounted) {
         state = resolveCatalogRefreshError(
@@ -155,6 +157,21 @@ class ChannelVideosNotifier extends Notifier<AsyncValue<List<Video>>> {
         );
       }
     }
+  }
+
+  /// Best-effort: ask the backend to pre-generate previews for the first few
+  /// not-yet-playable videos so opening one lands on the ready-preview fast
+  /// path. Skips already-downloaded / already-previewed videos.
+  void _prewarm(List<Video> videos) {
+    final ids = videos
+        .where((v) => !v.isPlayable)
+        .take(AppConstants.prewarmBatchSize)
+        .map((v) => v.id)
+        .toList();
+    if (ids.isEmpty) return;
+    // Detached and best-effort: a prewarm failure must never affect the load,
+    // so the call is deferred (swallowing even a synchronous throw) and ignored.
+    Future(() => _api.prewarmPreviews(ids)).ignore();
   }
 }
 

--- a/lib/providers/queue_provider.dart
+++ b/lib/providers/queue_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../config/constants.dart';
 import '../models/video.dart';
 import '../services/api_service.dart';
 
@@ -99,6 +100,7 @@ class QueueNotifier extends Notifier<QueueState> {
         isLoading: false,
         isLoadingMore: false,
       );
+      _prewarm(page.items);
     } catch (e) {
       if (requestId != _requestId) return;
       state = state.copyWith(
@@ -106,6 +108,21 @@ class QueueNotifier extends Notifier<QueueState> {
         error: e is ApiException ? e.message : 'Failed to load your queue.',
       );
     }
+  }
+
+  /// Best-effort: ask the backend to pre-generate previews for the first few
+  /// not-yet-playable queued videos so opening one lands on the ready-preview
+  /// fast path. Skips already-downloaded / already-previewed videos.
+  void _prewarm(List<Video> videos) {
+    final ids = videos
+        .where((v) => !v.isPlayable)
+        .take(AppConstants.prewarmBatchSize)
+        .map((v) => v.id)
+        .toList();
+    if (ids.isEmpty) return;
+    // Detached and best-effort: a prewarm failure must never affect the load,
+    // so the call is deferred (swallowing even a synchronous throw) and ignored.
+    Future(() => _api.prewarmPreviews(ids)).ignore();
   }
 
   /// Re-runs the first-page load (pull-to-refresh, retry after error).

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -484,6 +484,17 @@ class ApiService {
     await _dio.post('$_baseUrl${AppConstants.videoPreview(videoId)}');
   });
 
+  /// Pre-generates 360p previews for [videoIds] the user is likely to play next,
+  /// so a later tap lands on the ready-preview fast path instead of the cold
+  /// instant-stream path. Best-effort; the backend dedupes and caps the batch.
+  Future<void> prewarmPreviews(List<String> videoIds) => _guard(() async {
+    if (videoIds.isEmpty) return;
+    await _dio.post(
+      '$_baseUrl${AppConstants.videosPrewarm}',
+      data: {'video_ids': videoIds},
+    );
+  });
+
   /// Builds the authenticated 360p preview stream URL for [id]. Like
   /// [getVideoStreamUrl] it carries a short-lived playback ticket rather than
   /// the session token. Throws [ApiException] if the ticket can't be minted.

--- a/test/unit/api_service_test.dart
+++ b/test/unit/api_service_test.dart
@@ -192,6 +192,31 @@ void main() {
     });
   });
 
+  group('prewarmPreviews', () {
+    test('POSTs the prewarm endpoint with the ids', () async {
+      final adapter = _FakeAdapter((_) => _json({'enqueued': []}));
+      final api = apiWith(adapter);
+
+      await api.prewarmPreviews(['a', 'b']);
+
+      final req = adapter.requests.single;
+      expect(req.method, 'POST');
+      expect(req.uri.path, AppConstants.videosPrewarm);
+      expect(req.data, {
+        'video_ids': ['a', 'b'],
+      });
+    });
+
+    test('empty list makes no request', () async {
+      final adapter = _FakeAdapter((_) => _json({}));
+      final api = apiWith(adapter);
+
+      await api.prewarmPreviews([]);
+
+      expect(adapter.requests, isEmpty);
+    });
+  });
+
   group('getWsTicket', () {
     test('POSTs the ws-ticket endpoint and caches the result', () async {
       var n = 0;


### PR DESCRIPTION
## What

Track 3 client side. When a **channel detail** page or the **watch-later queue** finishes loading, the app asks the backend to pre-generate 360p previews (`POST /videos/prewarm`) for the not-yet-playable videos shown — so a later tap lands on the **ready-preview fast path** instead of the cold instant-stream path.

Backend support merged in windoze95/nullfeed-backend#87.

## Changes

- `api_service.dart`: `prewarmPreviews(List<String>)` → `POST /api/videos/prewarm` with `{video_ids}`. `constants.dart`: `videosPrewarm` + `prewarmBatchSize` (12).
- `ChannelVideosNotifier` / `QueueNotifier`: after a successful load, prewarm the first N videos where `!isPlayable`. The call is **fully detached** (`Future(() => …).ignore()`) so a prewarm failure can never affect the load.

## Why not the home feed

Its sections are **downloaded-only** (`status == COMPLETE`), so there's nothing to pre-generate there. Channel detail (cataloged uploads) and the queue are where not-downloaded videos appear.

## Verification

`dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` → No issues, `flutter test` → **154 passed** (+2 prewarmPreviews tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)