### PR TITLE
feat(player): skip detected sponsor segments during playback

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -78,6 +78,7 @@ class AppConstants {
   static String videoStream(String id) => '$apiBase/videos/$id/stream';
   static String videoInstantStream(String id) =>
       '$apiBase/videos/$id/instant-stream';
+  static String videoAdSegments(String id) => '$apiBase/videos/$id/ad-segments';
   static String videoProgress(String id) => '$apiBase/videos/$id/progress';
   static String videoDownload(String id) => '$apiBase/videos/$id/download';
   static String videoCancel(String id) => '$apiBase/videos/$id/cancel';

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -47,6 +47,12 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   bool _showResumeBanner = false;
   Timer? _resumeBannerTimer;
 
+  /// Detected sponsor/ad segments (seconds); the playhead seeks past any it
+  /// enters. Empty until loaded, or when there are none / detection is pending.
+  List<({double start, double end})> _adSegments = const [];
+  bool _showSkipToast = false;
+  Timer? _skipToastTimer;
+
   /// Set once auto-advance has fired so a stream of post-completion ticks can't
   /// trigger it again.
   bool _advancing = false;
@@ -275,6 +281,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _maybeShowResumeBanner();
     _startProgressTimer();
     _scheduleHideControls();
+    unawaited(_loadAdSegments());
     return true;
   }
 
@@ -525,7 +532,44 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   void _onControllerUpdate() {
     final controller = _controller;
     if (controller == null || !controller.value.isInitialized) return;
+    _maybeSkipAd();
     if (controller.value.isCompleted) _handleCompletion();
+  }
+
+  /// Seek past any sponsor segment the playhead has entered, flashing a brief
+  /// "Skipped sponsor" toast. The 0.5s tail margin stops a seek to a segment's
+  /// end from immediately re-triggering the same segment.
+  void _maybeSkipAd() {
+    final controller = _controller;
+    if (controller == null || _adSegments.isEmpty) return;
+    final pos = controller.value.position.inMilliseconds / 1000.0;
+    for (final seg in _adSegments) {
+      if (pos >= seg.start && pos < seg.end - 0.5) {
+        controller.seekTo(Duration(milliseconds: (seg.end * 1000).round()));
+        _flashSkipToast();
+        break;
+      }
+    }
+  }
+
+  /// Best-effort: fetch detected sponsor segments for this video. No skipping
+  /// happens if detection is still pending, finds none, or is unavailable.
+  Future<void> _loadAdSegments() async {
+    try {
+      final segments = await _api.getAdSegments(widget.videoId);
+      if (mounted) setState(() => _adSegments = segments);
+    } catch (_) {
+      // Best-effort; leave _adSegments empty.
+    }
+  }
+
+  void _flashSkipToast() {
+    if (!mounted) return;
+    if (!_showSkipToast) setState(() => _showSkipToast = true);
+    _skipToastTimer?.cancel();
+    _skipToastTimer = Timer(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _showSkipToast = false);
+    });
   }
 
   /// When the video plays through to the end, advance into the queue: consume
@@ -629,6 +673,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _progressTimer?.cancel();
     _hideControlsTimer?.cancel();
     _resumeBannerTimer?.cancel();
+    _skipToastTimer?.cancel();
     _previewTimeout?.cancel();
     _previewPollTimer?.cancel();
     _previewMaxWait?.cancel();
@@ -821,6 +866,32 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
                         position: Duration(seconds: _resumeFromSeconds!),
                         onRestart: _restartFromStart,
                         onDismiss: _dismissResumeBanner,
+                      ),
+                    ),
+                  ),
+                ),
+
+              // Sponsor-skip toast: shown briefly after auto-skipping a segment.
+              if (_showSkipToast && _isInitialized)
+                Positioned(
+                  bottom: 80,
+                  left: 0,
+                  right: 0,
+                  child: SafeArea(
+                    child: Center(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 6,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.black87,
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        child: const Text(
+                          'Skipped sponsor',
+                          style: TextStyle(color: Colors.white, fontSize: 13),
+                        ),
                       ),
                     ),
                   ),

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -480,6 +480,24 @@ class ApiService {
     await _dio.post('$_baseUrl${AppConstants.videoCache(videoId)}');
   });
 
+  /// Fetches detected sponsor/ad segments (seconds) for client-side skipping.
+  /// Returns an empty list when detection is still pending or finds no ads.
+  Future<List<({double start, double end})>> getAdSegments(String videoId) =>
+      _guard(() async {
+        final response = await _dio.get(
+          '$_baseUrl${AppConstants.videoAdSegments(videoId)}',
+        );
+        final data = response.data as Map<String, dynamic>;
+        final segments = (data['segments'] as List?) ?? const [];
+        return [
+          for (final s in segments)
+            (
+              start: (s['start'] as num).toDouble(),
+              end: (s['end'] as num).toDouble(),
+            ),
+        ];
+      });
+
   Future<void> requestPreview(String videoId) => _guard(() async {
     await _dio.post('$_baseUrl${AppConstants.videoPreview(videoId)}');
   });

--- a/test/unit/api_service_test.dart
+++ b/test/unit/api_service_test.dart
@@ -217,6 +217,37 @@ void main() {
     });
   });
 
+  group('getAdSegments', () {
+    test('GETs the endpoint and parses segments (ints and doubles)', () async {
+      final adapter = _FakeAdapter(
+        (_) => _json({
+          'status': 'READY',
+          'segments': [
+            {'start': 10.0, 'end': 25.5, 'category': 'sponsor'},
+            {'start': 100, 'end': 130, 'category': 'selfpromo'},
+          ],
+        }),
+      );
+      final api = apiWith(adapter);
+
+      final segs = await api.getAdSegments('vid-7');
+
+      final req = adapter.requests.single;
+      expect(req.method, 'GET');
+      expect(req.uri.path, AppConstants.videoAdSegments('vid-7'));
+      expect(segs, [(start: 10.0, end: 25.5), (start: 100.0, end: 130.0)]);
+    });
+
+    test('returns an empty list when detection is pending', () async {
+      final adapter = _FakeAdapter(
+        (_) => _json({'status': 'PENDING', 'segments': []}),
+      );
+      final api = apiWith(adapter);
+
+      expect(await api.getAdSegments('vid-8'), isEmpty);
+    });
+  });
+
   group('getWsTicket', () {
     test('POSTs the ws-ticket endpoint and caches the result', () async {
       var n = 0;


### PR DESCRIPTION
## What

Client side of sponsor-skip. When playback starts, the player fetches the video's detected sponsor segments and **seeks past any the playhead enters**, flashing a brief "Skipped sponsor" toast.

Backend: windoze95/nullfeed-backend#88 (`GET /ad-segments`).

## Changes

- **`api_service.dart`**: `getAdSegments(id)` → `GET /api/videos/{id}/ad-segments`, returns `[(start, end)]` seconds (empty when detection is pending or finds none; handles int or double JSON). **`constants.dart`**: `videoAdSegments`.
- **`video_player_screen.dart`**: load segments on playback start (best-effort); `_onControllerUpdate` (fires on every position tick) seeks past a segment when the playhead enters it, with a 0.5s tail margin so seeking to the end doesn't re-trigger; "Skipped sponsor" toast overlay with a timer cleaned up in `dispose`. Works across the preview→HQ swap (state persists; listener re-attaches to the new controller).

## Verification

`dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` → No issues, `flutter test` → **156 passed** (+2 getAdSegments tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)