### PR TITLE
feat(channel): drop per-video "Remove from library" action

### DIFF
--- a/lib/screens/channel_detail_screen.dart
+++ b/lib/screens/channel_detail_screen.dart
@@ -422,62 +422,9 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
               video: video,
               onTap: () => Navigator.pop(sheetContext),
             ),
-            ListTile(
-              leading: const Icon(
-                Icons.delete_outline,
-                color: NullFeedTheme.errorColor,
-              ),
-              title: const Text('Remove from library'),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                _confirmRemove(video);
-              },
-            ),
           ],
         ),
       ),
     );
-  }
-
-  Future<void> _confirmRemove(Video video) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: NullFeedTheme.cardColor,
-        title: const Text('Remove from library?'),
-        content: Text(
-          '"${video.title}" will be removed from your library. The downloaded '
-          'file is deleted from the server once no other profile has it.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            child: const Text(
-              'Remove',
-              style: TextStyle(color: NullFeedTheme.errorColor),
-            ),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true || !mounted) return;
-
-    try {
-      await ref.read(apiServiceProvider).deleteVideo(video.id);
-      if (!mounted) return;
-      ref.invalidate(channelVideosProvider(widget.channelId));
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Removed from library')));
-    } on ApiException catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(e.message)));
-    }
   }
 }


### PR DESCRIPTION
## What

Follow-up to the invisible-caching redesign (#52). Removes the per-video **"Remove from library"** action from the channel-detail ⋯ menu.

Per-episode "remove from library" is collection-curation, which no longer fits the model: your library is your **followed channels + watch-later**, and you manage it by following/unfollowing (cache eviction handles disk automatically). The ⋯ menu is now **watch-later only**, matching tvOS.

## Changes

- Removed the "Remove from library" `ListTile` and its confirm dialog (`_confirmRemove`) from `channel_detail_screen.dart`.
- `api_service.deleteVideo` is kept (still used by `video_provider`).

## Verification

`flutter analyze --fatal-infos --fatal-warnings` → No issues, `flutter test` → **156 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)