### PR TITLE
feat(web): responsive desktop UX — NavigationRail + wider grids

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -14,6 +14,8 @@ import '../screens/channel_detail_screen.dart';
 import '../screens/video_player_screen.dart';
 import '../screens/search_screen.dart';
 import '../screens/queue_screen.dart';
+import '../widgets/adaptive_layout.dart';
+import 'theme.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _shellNavigatorKey = GlobalKey<NavigatorState>();
@@ -160,6 +162,34 @@ class _ScaffoldWithNav extends ConsumerWidget {
     ref.watch(webSocketConnectionProvider);
     final destinations = _destinations;
     final selectedIndex = _calculateSelectedIndex(context);
+
+    // Wide viewports (desktop/web, iPad landscape) get a side NavigationRail;
+    // phones keep the bottom nav.
+    if (AdaptiveLayout.isWide(context)) {
+      return Scaffold(
+        body: Row(
+          children: [
+            NavigationRail(
+              selectedIndex: selectedIndex,
+              onDestinationSelected: (index) =>
+                  context.go(destinations[index].route),
+              labelType: NavigationRailLabelType.all,
+              backgroundColor: NullFeedTheme.surfaceColor,
+              destinations: [
+                for (final d in destinations)
+                  NavigationRailDestination(
+                    icon: Icon(d.icon),
+                    selectedIcon: Icon(d.activeIcon),
+                    label: Text(d.label),
+                  ),
+              ],
+            ),
+            const VerticalDivider(width: 1),
+            Expanded(child: child),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       body: child,

--- a/lib/widgets/adaptive_layout.dart
+++ b/lib/widgets/adaptive_layout.dart
@@ -31,7 +31,18 @@ class AdaptiveLayout extends StatelessWidget {
     };
   }
 
+  /// Breakpoint at/above which a side NavigationRail replaces the bottom nav
+  /// (desktop browsers, large windows, iPad landscape).
+  static const double wideBreakpoint = 900;
+
+  static bool isWide(BuildContext context) =>
+      MediaQuery.sizeOf(context).width >= wideBreakpoint;
+
   static int gridCrossAxisCount(BuildContext context) {
+    // Make use of wide desktop/web viewports instead of capping at 3.
+    final width = MediaQuery.sizeOf(context).width;
+    if (width >= 1500) return 5;
+    if (width >= 1150) return 4;
     return switch (getDeviceType(context)) {
       DeviceType.tablet => 3,
       DeviceType.phone => 2,


### PR DESCRIPTION
## What

Desktop/web UX polish so the app feels native on a wide window (and iPad landscape) instead of showing a phone bottom-bar.

- **Wide viewports (≥900px) get a side `NavigationRail`**; phones keep the bottom nav. Both are driven by the same destinations list, so the web-hidden Offline tab stays consistent.
- **`gridCrossAxisCount` scales with width** — 4 columns ≥1150px, 5 ≥1500px (was capped at 3) — so the Library/Discover grids use the extra space.

## Verification

`flutter analyze --fatal-infos --fatal-warnings` → No issues; `flutter test` → **156 passed**; `flutter build web` → succeeds. (The rail renders for authenticated tabs, so it's viewable once the bundle is served from the backend — verified here by build + tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)