### PR TITLE
fix(player): bound playback init so a stalled stream can't spin forever

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -100,6 +100,12 @@ class AppConstants {
   /// indefinite spinner.
   static const int previewMaxWaitSeconds = 180;
 
+  /// Cap on how long a single playback source may take to initialize. If a
+  /// stream (especially the proxied instant-stream) stalls while loading, the
+  /// player abandons it instead of spinning forever — for the cold-press path
+  /// that means falling back to a preview; for others, a graceful error.
+  static const int playbackInitTimeoutSeconds = 25;
+
   /// Max videos one /prewarm call asks the backend to pre-generate previews for.
   static const int prewarmBatchSize = 12;
 

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -232,6 +232,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     Video video, {
     bool isPreview = false,
     bool reportErrors = true,
+    Duration initTimeout = const Duration(
+      seconds: AppConstants.playbackInitTimeoutSeconds,
+    ),
   }) async {
     // A WS event and a poll tick can race to start playback; only the first
     // caller proceeds (checked-and-set synchronously, before any await).
@@ -241,7 +244,10 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     final controller = VideoPlayerController.networkUrl(Uri.parse(url));
 
     try {
-      await controller.initialize();
+      // Bound init so a stalled source (e.g. a wedged instant-stream proxy)
+      // can't leave the player spinning forever — on timeout we treat it as a
+      // load failure so the caller can fall back / surface an error.
+      await controller.initialize().timeout(initTimeout);
     } catch (e) {
       controller.dispose();
       _startingPlayback = false;


### PR DESCRIPTION
## Bug

Tapping some episodes **sometimes just spins on "Preparing your video…"** with no recovery.

## Root cause

`VideoPlayerController.initialize()` in `_startPlayback` had **no timeout**. The cold-press path awaits the instant-stream proxy; if that stalls (see the backend fix windoze95/nullfeed-backend#93), the `await` never completes — so it never returns to fall through to the **preview fallback** (which *does* have graceful 90s/180s timeouts). Result: an indefinite spinner.

## Fix

Bound `controller.initialize()` at **`playbackInitTimeoutSeconds` (25s)**. A timeout is treated as a load failure:
- cold-press / instant-stream (`reportErrors: false`) → returns false → falls back to the preview path (bounded + graceful error),
- HQ / preview paths → surface the "taking longer than expected" error.

So no playback path can hang forever, regardless of backend behavior. Defense-in-depth with the backend's first-byte cap.

## Verification

`flutter analyze --fatal-infos --fatal-warnings` → No issues; `flutter test` → **156 passed**; `flutter build web` → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)