### PR TITLE
feat(settings): browser-aware "get the cookies.txt extension" link

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
@@ -10,6 +11,7 @@ import '../providers/websocket_provider.dart';
 import '../services/api_service.dart';
 import '../config/constants.dart';
 import '../config/theme.dart';
+import '../utils/browser_link.dart';
 import '../widgets/adaptive_layout.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
@@ -420,6 +422,7 @@ class _YoutubeCookiesSectionState
   @override
   Widget build(BuildContext context) {
     final status = _status;
+    final browser = detectedBrowserName();
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -446,6 +449,26 @@ class _YoutubeCookiesSectionState
                 context,
               ).textTheme.bodySmall?.copyWith(color: NullFeedTheme.textMuted),
             ),
+            if (kIsWeb) ...[
+              const SizedBox(height: 4),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  onPressed: () => openInNewTab(cookieExtensionUrl()),
+                  icon: const Icon(Icons.extension_outlined, size: 18),
+                  label: Text(
+                    browser == null
+                        ? "Get the 'cookies.txt' extension"
+                        : "Get the 'cookies.txt' extension for $browser",
+                  ),
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
+              ),
+            ],
             const SizedBox(height: 12),
             TextField(
               controller: _controller,

--- a/lib/utils/browser_link.dart
+++ b/lib/utils/browser_link.dart
@@ -1,0 +1,8 @@
+// Picks the right "Get cookies.txt LOCALLY" extension store link for the
+// current browser (web only) and opens it.
+//
+// Browser extensions are installed in a desktop browser — which is exactly
+// where the web app runs — so this is a web-only affordance. On native (iOS)
+// the stub returns null / a no-op and the UI just shows the instructions.
+export 'browser_link_stub.dart'
+    if (dart.library.js_interop) 'browser_link_web.dart';

--- a/lib/utils/browser_link_stub.dart
+++ b/lib/utils/browser_link_stub.dart
@@ -1,0 +1,7 @@
+/// Native (non-web) fallback: there's no host browser to detect or open into.
+String? detectedBrowserName() => null;
+
+String cookieExtensionUrl() =>
+    'https://github.com/kairi003/Get-cookies.txt-LOCALLY';
+
+void openInNewTab(String url) {}

--- a/lib/utils/browser_link_web.dart
+++ b/lib/utils/browser_link_web.dart
@@ -1,0 +1,30 @@
+import 'package:web/web.dart' as web;
+
+/// The host browser's friendly name, or null if it can't be identified.
+String? detectedBrowserName() {
+  final ua = web.window.navigator.userAgent.toLowerCase();
+  // Order matters: Edge's UA contains "chrome", and Chrome's contains "safari".
+  if (ua.contains('firefox')) return 'Firefox';
+  if (ua.contains('edg/')) return 'Edge';
+  if (ua.contains('chrome') || ua.contains('chromium')) return 'Chrome';
+  if (ua.contains('safari')) return 'Safari';
+  return null;
+}
+
+/// Store link for "Get cookies.txt LOCALLY" matching the host browser.
+String cookieExtensionUrl() {
+  switch (detectedBrowserName()) {
+    case 'Firefox':
+      return 'https://addons.mozilla.org/en-US/firefox/addon/get-cookies-txt-locally/';
+    case 'Safari':
+      // Not available for Safari — the repo points to the supported browsers.
+      return 'https://github.com/kairi003/Get-cookies.txt-LOCALLY';
+    default:
+      // Chrome, Edge (installs from the Chrome store), and other Chromium.
+      return 'https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc';
+  }
+}
+
+void openInNewTab(String url) {
+  web.window.open(url, '_blank');
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
+  web: ^1.1.1
   flutter_riverpod: ^3.2.1
   riverpod_annotation: ^4.0.2
   dio: ^5.7.0


### PR DESCRIPTION
## What

Follow-up to the cookie-settings UI (#59): in the **YouTube Account** panel, add a one-tap link to install the **"Get cookies.txt LOCALLY"** extension, pointing at the **right store for the browser** viewing the web app:

- Chrome / Edge / Chromium → Chrome Web Store
- Firefox → Firefox Add-ons
- Safari → the project repo (the extension isn't on Safari)

## How

A tiny conditional-import helper (`browser_link.dart` + `_stub` + `_web`): the web impl reads `navigator.userAgent` and uses `window.open` via `package:web` (now a direct dep, was transitive); the native stub is a no-op. The button only renders on web (`kIsWeb`) — you install a browser extension in the desktop browser the web app is running in, not the iOS app.

## Verification

`flutter analyze --fatal-infos --fatal-warnings` → No issues; `flutter test` → **156 passed**; `flutter build web` → succeeds (web interop compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)