### PR TITLE
feat(settings): show the actual reason cookies aren't working

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -343,7 +343,8 @@ class _YoutubeCookiesSection extends ConsumerStatefulWidget {
 class _YoutubeCookiesSectionState
     extends ConsumerState<_YoutubeCookiesSection> {
   final _controller = TextEditingController();
-  ({bool configured, bool stale, String? updatedAt})? _status;
+  ({bool configured, bool stale, String? updatedAt, String? lastError})?
+  _status;
   bool _loading = true;
   bool _busy = false;
   String? _error;
@@ -521,7 +522,9 @@ class _YoutubeCookiesSectionState
     );
   }
 
-  Widget _statusRow(({bool configured, bool stale, String? updatedAt})? s) {
+  Widget _statusRow(
+    ({bool configured, bool stale, String? updatedAt, String? lastError})? s,
+  ) {
     if (s == null || !s.configured) {
       return const Row(
         children: [
@@ -532,17 +535,35 @@ class _YoutubeCookiesSectionState
       );
     }
     if (s.stale) {
-      return const Row(
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(
-            Icons.warning_amber_rounded,
-            color: NullFeedTheme.errorColor,
-            size: 18,
+          const Row(
+            children: [
+              Icon(
+                Icons.warning_amber_rounded,
+                color: NullFeedTheme.errorColor,
+                size: 18,
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  "Cookies aren't working — re-export and paste fresh ones",
+                ),
+              ),
+            ],
           ),
-          SizedBox(width: 8),
-          Expanded(
-            child: Text('Cookies expired — paste fresh ones to keep playing'),
-          ),
+          if (s.lastError != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              s.lastError!,
+              style: const TextStyle(
+                color: NullFeedTheme.textMuted,
+                fontSize: 11,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ],
         ],
       );
     }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -453,23 +453,22 @@ class ApiService {
   });
 
   // YouTube cookies (admin only) — enables age-restricted / members-only videos.
-  ({bool configured, bool stale, String? updatedAt}) _parseCookieStatus(
-    Map<String, dynamic> data,
-  ) => (
+  ({bool configured, bool stale, String? updatedAt, String? lastError})
+  _parseCookieStatus(Map<String, dynamic> data) => (
     configured: data['configured'] == true,
     stale: data['stale'] == true,
     updatedAt: data['updated_at'] as String?,
+    lastError: data['last_error'] as String?,
   );
 
-  Future<({bool configured, bool stale, String? updatedAt})>
+  Future<({bool configured, bool stale, String? updatedAt, String? lastError})>
   getYoutubeCookiesStatus() => _guard(() async {
     final r = await _dio.get('$_baseUrl${AppConstants.settingsYoutubeCookies}');
     return _parseCookieStatus(r.data as Map<String, dynamic>);
   });
 
-  Future<({bool configured, bool stale, String? updatedAt})> saveYoutubeCookies(
-    String cookies,
-  ) => _guard(() async {
+  Future<({bool configured, bool stale, String? updatedAt, String? lastError})>
+  saveYoutubeCookies(String cookies) => _guard(() async {
     final r = await _dio.put(
       '$_baseUrl${AppConstants.settingsYoutubeCookies}',
       data: {'cookies': cookies},


### PR DESCRIPTION
Companion to windoze95/nullfeed-backend#98. The YouTube Account panel now renders the backend's `last_error` — when cookies are present but extraction keeps failing, it shows the real yt-dlp message (e.g. *"…does not look like a Netscape format cookies file"*) under a clear "Cookies aren't working — re-export and paste fresh ones" warning, instead of a vague "expired". No more guessing why a video won't play.

analyze clean, 156 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)