### PR TITLE
Banner unplayable videos with the reason (age-restricted, members-only, …)

### DIFF
--- a/lib/models/video.dart
+++ b/lib/models/video.dart
@@ -17,6 +17,70 @@ enum VideoStatus {
   failed,
 }
 
+/// Why YouTube refuses this video, as classified by the backend from yt-dlp
+/// failures and playlist availability badges. Null on the wire means playable
+/// as far as the server knows; [unknown] absorbs vocabulary the backend adds
+/// before this client learns it (still bannered, just generically).
+enum UnplayableReason {
+  @JsonValue('age_restricted')
+  ageRestricted,
+  @JsonValue('members_only')
+  membersOnly,
+  @JsonValue('premium')
+  premium,
+  @JsonValue('private')
+  private,
+  @JsonValue('geo_blocked')
+  geoBlocked,
+  @JsonValue('removed')
+  removed,
+  @JsonValue('drm')
+  drm,
+  @JsonValue('upcoming')
+  upcoming,
+  @JsonValue('unavailable')
+  unavailable,
+  unknown,
+}
+
+extension UnplayableReasonLabels on UnplayableReason {
+  /// Short uppercase-style banner text for thumbnails.
+  String get label => switch (this) {
+    UnplayableReason.ageRestricted => 'Age-restricted',
+    UnplayableReason.membersOnly => 'Members only',
+    UnplayableReason.premium => 'Premium',
+    UnplayableReason.private => 'Private',
+    UnplayableReason.geoBlocked => 'Geo-blocked',
+    UnplayableReason.removed => 'Removed',
+    UnplayableReason.drm => 'DRM-protected',
+    UnplayableReason.upcoming => 'Upcoming',
+    UnplayableReason.unavailable || UnplayableReason.unknown => 'Unavailable',
+  };
+
+  /// One-sentence explanation for menus and the player's blocked view.
+  String get description => switch (this) {
+    UnplayableReason.ageRestricted =>
+      'YouTube age-restricts this video. It can play once the server has '
+          'working YouTube cookies from an age-verified account.',
+    UnplayableReason.membersOnly =>
+      'This video is exclusive to channel members on YouTube, so the server '
+          'can\'t fetch it.',
+    UnplayableReason.premium =>
+      'YouTube requires payment or a Premium subscription for this video.',
+    UnplayableReason.private => 'The uploader made this video private.',
+    UnplayableReason.geoBlocked =>
+      'This video isn\'t available in the server\'s country.',
+    UnplayableReason.removed =>
+      'This video was removed from YouTube or its account was terminated.',
+    UnplayableReason.drm =>
+      'This video is DRM-protected and can\'t be fetched.',
+    UnplayableReason.upcoming =>
+      'This video hasn\'t premiered yet. It becomes playable once it airs.',
+    UnplayableReason.unavailable ||
+    UnplayableReason.unknown => 'YouTube reports this video as unavailable.',
+  };
+}
+
 @freezed
 abstract class Video with _$Video {
   const factory Video({
@@ -40,6 +104,12 @@ abstract class Video with _$Video {
     DateTime? lastWatchedAt,
     // Preview
     @JsonKey(name: 'preview_status') String? previewStatus,
+    // Why YouTube refuses this video (see UnplayableReason); null = playable.
+    @JsonKey(
+      name: 'unplayable_reason',
+      unknownEnumValue: UnplayableReason.unknown,
+    )
+    UnplayableReason? unplayableReason,
     // Joined from channel
     @JsonKey(name: 'channel_name') @Default('') String channelName,
   }) = _Video;
@@ -54,6 +124,11 @@ const int _resumeRewindSeconds = 10;
 extension VideoExtensions on Video {
   bool get isPlayable =>
       status == VideoStatus.complete || previewStatus == 'READY';
+
+  /// The unplayable reason worth showing. A video we already hold a playable
+  /// file for (HQ or preview) plays regardless of a stale label, so no banner.
+  UnplayableReason? get activeUnplayableReason =>
+      isPlayable ? null : unplayableReason;
 
   bool get hasPreviewReady => previewStatus == 'READY';
 

--- a/lib/screens/channel_detail_screen.dart
+++ b/lib/screens/channel_detail_screen.dart
@@ -8,6 +8,7 @@ import '../providers/feed_provider.dart';
 import '../services/api_service.dart';
 import '../services/storage_service.dart';
 import '../widgets/queue_action.dart';
+import '../widgets/unplayable_badge.dart';
 import '../widgets/video_list_tile.dart';
 import '../widgets/adaptive_layout.dart';
 import '../config/theme.dart';
@@ -418,6 +419,8 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
                 style: const TextStyle(color: NullFeedTheme.textMuted),
               ),
             ),
+            if (video.activeUnplayableReason != null)
+              UnplayableReasonTile(reason: video.activeUnplayableReason!),
             QueueActionTile(
               video: video,
               onTap: () => Navigator.pop(sheetContext),

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -17,6 +17,7 @@ import '../config/constants.dart';
 import '../config/theme.dart';
 import '../widgets/progress_bar.dart';
 import '../widgets/queue_action.dart';
+import '../widgets/unplayable_badge.dart';
 
 class VideoPlayerScreen extends ConsumerStatefulWidget {
   final String videoId;
@@ -64,6 +65,16 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   Video? _video;
 
   String? _error;
+
+  /// Why this video can't play (age-restricted, members-only, …), when the
+  /// server has it labeled. Renders an explanatory screen with a "Try anyway"
+  /// escape hatch instead of spinning through doomed stream attempts.
+  UnplayableReason? _blockedReason;
+
+  /// Set by "Try anyway": skip the [_blockedReason] gate for this screen so a
+  /// stale label can heal (the backend clears it on a successful resolve).
+  bool _ignoreUnplayableGate = false;
+
   late final ApiService _api;
   late final OfflineService _offline;
   StreamSubscription<WebSocketEvent>? _wsSubscription;
@@ -96,6 +107,72 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     ]);
   }
 
+  /// "Try anyway" on the blocked screen: retry with the gate off. If YouTube
+  /// now serves the video (cookies fixed, premiere aired) the server clears
+  /// the label and playback just starts; otherwise the normal error/timeout
+  /// paths report the failure.
+  void _tryAnyway() {
+    setState(() {
+      _ignoreUnplayableGate = true;
+      _blockedReason = null;
+    });
+    _initPlayer();
+  }
+
+  /// Full-screen explanation for a video YouTube refuses (age-restricted,
+  /// members-only, …), replacing the generic failure the doomed stream
+  /// attempts would eventually produce.
+  Widget _buildBlockedView(UnplayableReason reason) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              unplayableReasonIcon(reason),
+              color: unplayableReasonColor(reason),
+              size: 48,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              reason.label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Text(
+                reason.description,
+                style: const TextStyle(color: Colors.white70, fontSize: 14),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                OutlinedButton(
+                  onPressed: _tryAnyway,
+                  child: const Text('Try anyway'),
+                ),
+                const SizedBox(width: 12),
+                ElevatedButton(
+                  onPressed: _navigateBack,
+                  child: const Text('Go Back'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Future<void> _initPlayer() async {
     try {
       // Path 0: Offline — play the local file without requiring network.
@@ -109,6 +186,20 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       }
 
       final video = await _api.getVideo(widget.videoId);
+
+      // A video the server knows YouTube refuses (age-restricted,
+      // members-only, …) can't stream; explain instead of spinning through
+      // doomed attempts. Local files (paths 0-2 below) are unaffected —
+      // activeUnplayableReason is null whenever a playable file exists.
+      if (!_ignoreUnplayableGate && video.activeUnplayableReason != null) {
+        if (mounted) {
+          setState(() {
+            _video = video;
+            _blockedReason = video.activeUnplayableReason;
+          });
+        }
+        return;
+      }
 
       // Path 1: HQ complete — play directly
       if (video.status == VideoStatus.complete) {
@@ -145,6 +236,28 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
         }
       } on ApiException {
         // Couldn't mint a ticket / reach the server — fall back to a preview.
+      }
+
+      // The failed instant attempt may have just taught the server why this
+      // video can't stream (it classifies and stores the reason on a failed
+      // resolve) — re-check, so the viewer gets the explanation instead of a
+      // preview spinner doomed to time out the same way.
+      if (!_ignoreUnplayableGate && !_isInitialized) {
+        try {
+          final refreshed = await _api.getVideo(widget.videoId);
+          final reason = refreshed.activeUnplayableReason;
+          if (reason != null) {
+            if (mounted) {
+              setState(() {
+                _video = refreshed;
+                _blockedReason = reason;
+              });
+            }
+            return;
+          }
+        } on ApiException {
+          // Server unreachable — continue to the preview fallback.
+        }
       }
 
       // Fallback: request a preview, show spinner, and listen for it.
@@ -770,7 +883,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
             fit: StackFit.expand,
             children: [
               // Video
-              if (_error != null)
+              if (_blockedReason != null)
+                _buildBlockedView(_blockedReason!)
+              else if (_error != null)
                 Center(
                   child: Padding(
                     padding: const EdgeInsets.all(32),
@@ -830,7 +945,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
 
               // Back button while waiting for the player to come up — the
               // controls overlay only exists once playback started.
-              if (_error == null && !_isInitialized)
+              if (_error == null && _blockedReason == null && !_isInitialized)
                 SafeArea(
                   child: Align(
                     alignment: Alignment.topLeft,

--- a/lib/widgets/queue_action.dart
+++ b/lib/widgets/queue_action.dart
@@ -6,6 +6,7 @@ import '../config/theme.dart';
 import '../models/video.dart';
 import '../providers/queue_provider.dart';
 import '../services/api_service.dart';
+import 'unplayable_badge.dart';
 
 /// Adds or removes [video] from the watch-later queue and reports the outcome
 /// with a snackbar via the nearest [ScaffoldMessenger].
@@ -101,6 +102,8 @@ Future<void> showVideoActionsSheet(
               style: const TextStyle(color: NullFeedTheme.textMuted),
             ),
           ),
+          if (video.activeUnplayableReason != null)
+            UnplayableReasonTile(reason: video.activeUnplayableReason!),
           if (onPlay != null)
             ListTile(
               leading: const Icon(Icons.play_arrow),

--- a/lib/widgets/unplayable_badge.dart
+++ b/lib/widgets/unplayable_badge.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import '../config/theme.dart';
+import '../models/video.dart';
+
+/// Per-reason accent for [UnplayableBadge]. The chip itself keeps the shared
+/// black-badge background so it reads like the other thumbnail badges; the
+/// icon carries the color coding.
+Color unplayableReasonColor(UnplayableReason reason) => switch (reason) {
+  UnplayableReason.ageRestricted => NullFeedTheme.errorColor,
+  UnplayableReason.membersOnly => const Color(0xFFFFB74D),
+  UnplayableReason.premium => NullFeedTheme.primaryColor,
+  UnplayableReason.geoBlocked => const Color(0xFF64B5F6),
+  UnplayableReason.upcoming => const Color(0xFF4DB6AC),
+  UnplayableReason.private ||
+  UnplayableReason.removed ||
+  UnplayableReason.drm ||
+  UnplayableReason.unavailable ||
+  UnplayableReason.unknown => NullFeedTheme.textMuted,
+};
+
+IconData unplayableReasonIcon(UnplayableReason reason) => switch (reason) {
+  UnplayableReason.ageRestricted => Icons.explicit,
+  UnplayableReason.membersOnly => Icons.card_membership,
+  UnplayableReason.premium => Icons.workspace_premium,
+  UnplayableReason.private => Icons.lock,
+  UnplayableReason.geoBlocked => Icons.public_off,
+  UnplayableReason.removed => Icons.block,
+  UnplayableReason.drm => Icons.security,
+  UnplayableReason.upcoming => Icons.schedule,
+  UnplayableReason.unavailable ||
+  UnplayableReason.unknown => Icons.videocam_off,
+};
+
+/// Non-tappable actions-sheet row explaining why a video can't be played or
+/// downloaded, in a full sentence (the thumbnail badge only has room for a
+/// couple of words).
+class UnplayableReasonTile extends StatelessWidget {
+  final UnplayableReason reason;
+
+  const UnplayableReasonTile({super.key, required this.reason});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(
+        unplayableReasonIcon(reason),
+        color: unplayableReasonColor(reason),
+      ),
+      title: Text(reason.label),
+      subtitle: Text(
+        reason.description,
+        style: const TextStyle(color: NullFeedTheme.textMuted, fontSize: 12),
+      ),
+    );
+  }
+}
+
+/// Thumbnail banner explaining why a video can't be played or downloaded
+/// (age-restricted, members-only, premium, …). Sits in a tile's thumbnail
+/// [Stack]; [compact] shrinks it for the small list-tile thumbnails.
+class UnplayableBadge extends StatelessWidget {
+  final UnplayableReason reason;
+  final bool compact;
+
+  const UnplayableBadge({
+    super.key,
+    required this.reason,
+    this.compact = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final iconSize = compact ? 10.0 : 12.0;
+    final fontSize = compact ? 9.0 : 10.0;
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: compact ? 4 : 6,
+        vertical: compact ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.8),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            unplayableReasonIcon(reason),
+            color: unplayableReasonColor(reason),
+            size: iconSize,
+          ),
+          SizedBox(width: compact ? 3 : 4),
+          Text(
+            reason.label,
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: fontSize,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/video_card.dart
+++ b/lib/widgets/video_card.dart
@@ -11,6 +11,7 @@ import '../providers/feed_provider.dart';
 import '../providers/offline_provider.dart';
 import 'progress_bar.dart';
 import 'queue_action.dart';
+import 'unplayable_badge.dart';
 
 class VideoCard extends ConsumerStatefulWidget {
   final Video video;
@@ -45,6 +46,8 @@ class _VideoCardState extends ConsumerState<VideoCard> {
     final channel = widget.channel;
     if (channel != null) parts.add(channel.name);
     if (offlineStatus == 'complete') parts.add('downloaded');
+    final reason = widget.video.activeUnplayableReason;
+    if (reason != null) parts.add(reason.label);
     return parts.join(', ');
   }
 
@@ -142,6 +145,19 @@ class _VideoCardState extends ConsumerState<VideoCard> {
                                     Icons.play_circle_outline,
                                     color: NullFeedTheme.textMuted,
                                     size: 40,
+                                  ),
+                                ),
+
+                              // Why this video can't play (age-restricted,
+                              // members-only, …) — hidden once a local file
+                              // makes it playable anyway.
+                              if (widget.video.activeUnplayableReason != null)
+                                Positioned(
+                                  left: 6,
+                                  top: 6,
+                                  child: UnplayableBadge(
+                                    reason:
+                                        widget.video.activeUnplayableReason!,
                                   ),
                                 ),
 

--- a/lib/widgets/video_list_tile.dart
+++ b/lib/widgets/video_list_tile.dart
@@ -9,6 +9,7 @@ import '../config/theme.dart';
 import '../providers/offline_provider.dart';
 import '../services/offline_service.dart';
 import 'progress_bar.dart';
+import 'unplayable_badge.dart';
 
 class VideoListTile extends ConsumerStatefulWidget {
   final Video video;
@@ -54,6 +55,8 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
     if (v.isWatched) parts.add('watched');
     final state = _downloadStateLabel(offlineStatus);
     if (state != null) parts.add(state);
+    final reason = v.activeUnplayableReason;
+    if (reason != null) parts.add(reason.label);
     return parts.join(', ');
   }
 
@@ -199,6 +202,18 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
                                     child: const Icon(
                                       Icons.play_circle_outline,
                                       color: NullFeedTheme.textMuted,
+                                    ),
+                                  ),
+                                // Why this video can't play — hidden once a
+                                // local file makes it playable anyway.
+                                if (widget.video.activeUnplayableReason != null)
+                                  Positioned(
+                                    left: 4,
+                                    top: 4,
+                                    child: UnplayableBadge(
+                                      reason:
+                                          widget.video.activeUnplayableReason!,
+                                      compact: true,
                                     ),
                                   ),
                                 // Duration

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -206,6 +206,7 @@ Video makeVideo({
   String title = 'A Video',
   int durationSeconds = 600,
   VideoStatus status = VideoStatus.complete,
+  UnplayableReason? unplayableReason,
 }) {
   return Video(
     id: id,
@@ -214,6 +215,7 @@ Video makeVideo({
     title: title,
     durationSeconds: durationSeconds,
     status: status,
+    unplayableReason: unplayableReason,
   );
 }
 

--- a/test/unit/models_test.dart
+++ b/test/unit/models_test.dart
@@ -204,6 +204,58 @@ void main() {
       expect(video.uploadedAt, isNull);
       expect(video.status, VideoStatus.cataloged);
     });
+
+    test('maps unplayable_reason and round-trips it', () {
+      final video = Video.fromJson(const {
+        'id': 'v1',
+        'youtube_video_id': 'yt1',
+        'channel_id': 'c1',
+        'title': 'A Video',
+        'unplayable_reason': 'members_only',
+      });
+
+      expect(video.unplayableReason, UnplayableReason.membersOnly);
+      expect(video.activeUnplayableReason, UnplayableReason.membersOnly);
+      expect(Video.fromJson(video.toJson()), video);
+    });
+
+    test(
+      'absent unplayable_reason stays null; unknown values map to unknown',
+      () {
+        final absent = Video.fromJson(const {
+          'id': 'v1',
+          'youtube_video_id': 'yt1',
+          'channel_id': 'c1',
+          'title': 'A Video',
+        });
+        expect(absent.unplayableReason, isNull);
+
+        // Forward-compat: vocabulary this client doesn't know yet still banners.
+        final novel = Video.fromJson(const {
+          'id': 'v1',
+          'youtube_video_id': 'yt1',
+          'channel_id': 'c1',
+          'title': 'A Video',
+          'unplayable_reason': 'some_future_reason',
+        });
+        expect(novel.unplayableReason, UnplayableReason.unknown);
+        expect(novel.unplayableReason!.label, 'Unavailable');
+      },
+    );
+
+    test('a playable file suppresses the active reason', () {
+      final video = Video.fromJson(const {
+        'id': 'v1',
+        'youtube_video_id': 'yt1',
+        'channel_id': 'c1',
+        'title': 'A Video',
+        'status': 'COMPLETE',
+        'unplayable_reason': 'age_restricted',
+      });
+
+      expect(video.unplayableReason, UnplayableReason.ageRestricted);
+      expect(video.activeUnplayableReason, isNull);
+    });
   });
 
   group('Video resume', () {

--- a/test/widgets/unplayable_badge_test.dart
+++ b/test/widgets/unplayable_badge_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/config/theme.dart';
+import 'package:nullfeed/models/video.dart';
+import 'package:nullfeed/providers/offline_provider.dart';
+import 'package:nullfeed/widgets/unplayable_badge.dart';
+import 'package:nullfeed/widgets/video_card.dart';
+import 'package:nullfeed/widgets/video_list_tile.dart';
+
+Video makeVideo({
+  VideoStatus status = VideoStatus.cataloged,
+  UnplayableReason? unplayableReason,
+  String? previewStatus,
+}) {
+  // youtubeVideoId left blank so the tiles render their offline placeholder
+  // instead of reaching out for a network thumbnail during the test.
+  return Video(
+    id: 'v1',
+    youtubeVideoId: '',
+    channelId: 'c1',
+    title: 'Exclusive Episode',
+    status: status,
+    previewStatus: previewStatus,
+    unplayableReason: unplayableReason,
+  );
+}
+
+/// Pumps [child] with the offline status for v1 overridden so no Hive setup is
+/// needed.
+Future<void> pumpTile(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [offlineStatusProvider('v1').overrideWithValue(null)],
+      child: MaterialApp(
+        theme: NullFeedTheme.darkTheme,
+        home: Scaffold(body: child),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('badge shows the reason label and icon', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: UnplayableBadge(reason: UnplayableReason.membersOnly),
+        ),
+      ),
+    );
+
+    expect(find.text('Members only'), findsOneWidget);
+    expect(find.byIcon(Icons.card_membership), findsOneWidget);
+  });
+
+  testWidgets('video card banners an unplayable video', (tester) async {
+    await pumpTile(
+      tester,
+      VideoCard(
+        video: makeVideo(unplayableReason: UnplayableReason.ageRestricted),
+      ),
+    );
+
+    expect(find.byType(UnplayableBadge), findsOneWidget);
+    expect(find.text('Age-restricted'), findsOneWidget);
+  });
+
+  testWidgets('video card hides the banner once a playable file exists', (
+    tester,
+  ) async {
+    // A stale label on a downloaded (or preview-ready) video is ignored — the
+    // local file plays regardless of what YouTube refuses.
+    await pumpTile(
+      tester,
+      VideoCard(
+        video: makeVideo(
+          status: VideoStatus.complete,
+          unplayableReason: UnplayableReason.ageRestricted,
+        ),
+      ),
+    );
+
+    expect(find.byType(UnplayableBadge), findsNothing);
+  });
+
+  testWidgets('list tile banners an unplayable video compactly', (
+    tester,
+  ) async {
+    await pumpTile(
+      tester,
+      VideoListTile(
+        video: makeVideo(unplayableReason: UnplayableReason.membersOnly),
+        onTap: () {},
+      ),
+    );
+
+    final badge = tester.widget<UnplayableBadge>(find.byType(UnplayableBadge));
+    expect(badge.compact, isTrue);
+    expect(find.text('Members only'), findsOneWidget);
+  });
+
+  testWidgets('tile semantics mention the reason', (tester) async {
+    final handle = tester.ensureSemantics();
+    await pumpTile(
+      tester,
+      VideoListTile(
+        video: makeVideo(unplayableReason: UnplayableReason.premium),
+        onTap: () {},
+      ),
+    );
+
+    expect(
+      find.bySemanticsLabel(RegExp('Exclusive Episode.*Premium')),
+      findsOneWidget,
+    );
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Summary

Companion to backend windoze95/nullfeed-backend#112, which labels videos YouTube refuses with a nullable `unplayable_reason` (`age_restricted`, `members_only`, `premium`, `private`, `geo_blocked`, `removed`, `drm`, `upcoming`, `unavailable`). This PR surfaces those labels everywhere a video appears, so e.g. a members-only exclusive shows a "Members only" banner instead of failing generically.

## What's here

- **Model**: `UnplayableReason` enum (+ `label`/`description`), decoded unknown-value-tolerantly (`unknown` case) so future backend vocabulary still banners generically. `activeUnplayableReason` suppresses a stale label whenever a playable file (HQ or preview) exists — a downloaded video never banners.
- **Tiles**: `UnplayableBadge` chip on the thumbnail (home-feed cards + list tiles, compact variant), color/icon-coded per reason, matching the existing badge language. Tile semantics mention the reason.
- **Action sheets**: an explanatory `UnplayableReasonTile` row (full sentence) in both video menus.
- **Player**: a labeled video short-circuits to a blocked screen — reason icon, title, explanation, **Try anyway** + Go Back — instead of spinning through doomed stream attempts. "Try anyway" retries with the gate off; if YouTube now serves it (cookies fixed, premiere aired) the server clears the label and playback just starts. After a failed instant-stream attempt the player re-fetches the video so a freshly classified refusal (the backend stores it on the failed resolve) surfaces immediately.

Backward/forward compatible: field absent → everything renders exactly as before. Works identically on iOS and web (no `kIsWeb` needed — the badge is platform-agnostic).

## Tests

- Model: enum decode, round-trip, absent/unknown values, stale-label suppression.
- Widgets: badge renders label+icon; card banners an unplayable video and hides the banner once playable; list tile uses the compact variant; semantics include the reason.

`dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` clean, `flutter test` 164 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)