### PR TITLE
fix(player): PiP floats over other apps; restore tap-to-show-controls

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -26,18 +26,12 @@ class VideoPlayerScreen extends ConsumerStatefulWidget {
   ConsumerState<VideoPlayerScreen> createState() => _VideoPlayerScreenState();
 }
 
-class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen>
-    with WidgetsBindingObserver {
+class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   NfPlaybackController? _player;
 
   /// Whether this device can show Picture-in-Picture (iPhone iOS 14+); gates the
-  /// PiP button and auto-PiP. Set once playback starts.
+  /// PiP button. Set once playback starts.
   bool _pipSupported = false;
-
-  /// True while a PiP session we auto-started on backgrounding is active, so a
-  /// quick return to the app (e.g. a Control Center pull that didn't background
-  /// it) can dismiss it again.
-  bool _autoPipActive = false;
 
   Timer? _progressTimer;
   Timer? _hideControlsTimer;
@@ -98,7 +92,6 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
     _api = ref.read(apiServiceProvider);
     _offline = ref.read(offlineServiceProvider);
     _applyImmersiveMode();
@@ -118,30 +111,6 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen>
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
     ]);
-  }
-
-  /// iOS Picture-in-Picture: pop the video into a floating window when the app
-  /// is backgrounded mid-playback so it keeps playing over other apps.
-  ///
-  /// Best-effort — iOS only reliably allows *starting* PiP from the foreground,
-  /// so the PiP button is the guaranteed trigger. No-op on web / unsupported
-  /// devices. Audio keeps playing regardless via the background-audio setup.
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (!_pipSupported) return;
-    final player = _player;
-    if (player == null || !_isInitialized) return;
-    if (state == AppLifecycleState.inactive &&
-        player.isPlaying &&
-        !_autoPipActive) {
-      _autoPipActive = true;
-      unawaited(player.enterPip());
-    } else if (state == AppLifecycleState.resumed && _autoPipActive) {
-      // Back in the app: undo a PiP we auto-started that didn't lead to
-      // backgrounding (e.g. a Control Center pull).
-      _autoPipActive = false;
-      unawaited(player.exitPip());
-    }
   }
 
   /// After playback starts, ask the player whether this device supports PiP
@@ -921,7 +890,6 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen>
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
     _wsSubscription?.cancel();
     _adWsSubscription?.cancel();
     _progressTimer?.cancel();
@@ -974,6 +942,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen>
       child: Scaffold(
         backgroundColor: Colors.black,
         body: GestureDetector(
+          // opaque so taps anywhere over the video (which passes pointers
+          // through) reach onTap, not just where a child is hit.
+          behavior: HitTestBehavior.opaque,
           onTap: _toggleControls,
           onDoubleTapDown: (details) {
             final screenWidth = MediaQuery.of(context).size.width;

--- a/lib/services/playback/nf_playback_io_impl.dart
+++ b/lib/services/playback/nf_playback_io_impl.dart
@@ -185,7 +185,13 @@ class BetterPlayerNfController extends NfPlaybackController {
   }
 
   @override
-  Widget buildView() => BetterPlayer(controller: _controller, key: _viewKey);
+  Widget buildView() =>
+      // IgnorePointer so taps fall through to the screen's own GestureDetector
+      // (BetterPlayer otherwise swallows them); our controls are a separate
+      // overlay, and PiP uses native layers, so the video needs no gestures.
+      IgnorePointer(
+        child: BetterPlayer(controller: _controller, key: _viewKey),
+      );
 
   @override
   void dispose() {


### PR DESCRIPTION
Fixes two on-device issues found after #64.

## 1. Tapping the video didn't show the controls
The `BetterPlayer` widget swallows tap gestures before they reach the screen's `GestureDetector` — the old `video_player` `Texture` didn't. Fix: wrap the iOS video surface in `IgnorePointer` so taps fall through, and set `HitTestBehavior.opaque` on the screen's `GestureDetector` so a tap over the (now pass-through) video still triggers `onTap`. Our controls are a separate overlay and PiP uses native layers, so the video surface needs no gestures.

## 2. PiP didn't float over the home screen — it closed with the app
`enablePictureInPicture` *does* start a real system PiP, but the auto-PiP lifecycle handler re-invoked `enterPip()` on the `inactive` transition while backgrounding. better_player's `enablePictureInPicture()` first calls `disablePictureInPicture()` (removes its `AVPlayerLayer`) and rebuilds it — so re-triggering mid-transition tore down the PiP session that was about to detach and float.

Fix: remove the auto-PiP-on-background handler (and the `WidgetsBindingObserver` it needed). The **PiP button** now starts a real system PiP that correctly floats over other apps when you leave. Background audio is unaffected.

### Note on fully-automatic PiP
Auto-starting PiP the instant you background (no button tap) needs iOS's native `canStartPictureInPictureAutomaticallyFromInline`, which `better_player_plus` doesn't expose. That's a possible native follow-up; this PR ships the reliable button path.

## Testing
- `flutter analyze --fatal-infos --fatal-warnings` clean, 164 tests pass. Dart-only change (no pod/pubspec impact), so the web split and native build are unaffected — CI confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
