### PR TITLE
fix(player): scrubbing/skipping no longer auto-advances (seek-induced 'finished')

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -884,7 +884,18 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   void _seekRelative(int seconds) {
     final player = _player;
     if (player == null) return;
-    final target = player.position + Duration(seconds: seconds);
+    var target = player.position + Duration(seconds: seconds);
+    // Never skip onto/past the end. The player reports a seek beyond the
+    // duration as "finished" (video_player flips isCompleted at the end just
+    // the same), which would auto-advance to the next queued video instead of
+    // just nudging the playhead — so a skip-forward near the end must stay a
+    // moment short of the end. Natural end-of-playback still advances.
+    final duration = player.duration;
+    if (duration > Duration.zero) {
+      final maxTarget = duration - const Duration(seconds: 1);
+      if (target > maxTarget) target = maxTarget;
+    }
+    if (target < Duration.zero) target = Duration.zero;
     player.seekTo(target);
     setState(() => _showControls = true);
     _scheduleHideControls();

--- a/lib/services/playback/nf_playback_io_impl.dart
+++ b/lib/services/playback/nf_playback_io_impl.dart
@@ -109,7 +109,12 @@ class BetterPlayerNfController extends NfPlaybackController {
   void _onEvent(BetterPlayerEvent event) {
     switch (event.betterPlayerEventType) {
       case BetterPlayerEventType.finished:
-        if (!_completed) {
+        // better_player fires a *parameter-less* `finished` whenever a seek
+        // lands past the duration — which happens with a misreported/zero
+        // duration (some streams) even mid-video. Only genuine end-of-playback
+        // carries progress/duration parameters, so treat just that as
+        // completion; otherwise a skip/scrub would auto-advance the queue.
+        if (event.parameters != null && !_completed) {
           _completed = true;
           notifyListeners();
         }


### PR DESCRIPTION
## The bug
Tapping **skip-forward** jumped straight to the next video in the queue — and it happened **mid-video (first third)**, not near the end.

## Root cause (corrected)
better_player emits a `finished` event from **two** places, and they differ:

```dart
// 1) seek-induced — NO parameters (better_player_controller.dart:631)
if (moment > currentDuration) _postEvent(BetterPlayerEvent(BetterPlayerEventType.finished));

// 2) natural end-of-playback — WITH {progress, duration} parameters (:1091)
_postEvent(BetterPlayerEvent(BetterPlayerEventType.finished,
    parameters: {progress: ..., duration: ...}));
```

The screen treats any `finished` as end-of-video and auto-advances the queue. The trap: better_player compares the seek target against the **reported** duration, and some streams misreport it (zero/short) — so even a mid-video skip satisfies `moment > currentDuration` and fires the parameter-less `finished` → false auto-advance. (This is the same video whose *resume* also misbehaved, consistent with a bad reported duration.)

## Fix
The io player now treats `finished` as completion **only when it carries parameters** (genuine end-of-playback), ignoring the parameter-less seek-induced one. This holds no matter what duration the stream reports.

A secondary guard remains: skip targets are clamped to just short of the end, which also protects the web (`video_player`) backend, where `isCompleted` flips at the end.

## Testing
`flutter analyze --fatal-infos --fatal-warnings` clean, 164 tests pass. Worth an on-device confirm: skip forward/back mid-video → just moves the playhead, never jumps to the next video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
