### PR TITLE
fix(player): resume clamps to the real duration, not stale server metadata

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -459,9 +459,18 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     player.addListener(_onPlayerUpdate);
 
     // Resume from where the viewer left off (rewound a little so they can
-    // re-orient). A fresh or fully-watched video starts from the top.
+    // re-orient). A fresh or fully-watched video starts from the top. Clamp to
+    // the player's ACTUAL duration, not the server's durationSeconds (which can
+    // be stale/wrong and would otherwise drag the resume back toward the
+    // start while the banner still shows the saved position). Mirrors the
+    // offline path.
     if (video.canResume) {
-      await player.seekTo(Duration(seconds: video.resumeSeekSeconds));
+      final resumePos =
+          (video.watchPositionSeconds - AppConstants.skipBackwardSeconds).clamp(
+            0,
+            player.duration.inSeconds,
+          );
+      await player.seekTo(Duration(seconds: resumePos));
       _resumeFromSeconds = video.watchPositionSeconds;
     }
 


### PR DESCRIPTION
## The bug
Reopening a partly-watched video showed **"Resuming at 20-something minutes"** but playback **started at the beginning**. Only on one specific video; resume worked on the others.

## Root cause
The network playback path seeks to `video.resumeSeekSeconds`, which clamps the saved position to the **server's** `durationSeconds`:

```dart
int get resumeSeekSeconds {
  final maxSeconds = durationSeconds > 0 ? durationSeconds : watchPositionSeconds;
  return (watchPositionSeconds - _resumeRewindSeconds).clamp(0, maxSeconds);
}
```

If a video's server duration metadata is wrong/short (e.g. `durationSeconds` smaller than where you left off), the `.clamp` drags the resume target down toward `0`. Meanwhile the banner shows the raw `watchPositionSeconds` — so the banner said 20 min while the seek went near the start. It's video-specific (bad metadata for one video), which is why the others resumed fine.

The **offline** path never had this bug: it clamps to the *player's actual* duration.

## Fix
Make the network path do the same — clamp the resume target to `player.duration` (the real, loaded duration) instead of the server's `durationSeconds`. When the real duration is known (the normal case), resume lands correctly regardless of stale metadata.

## Testing
`flutter analyze --fatal-infos --fatal-warnings` clean, 164 tests pass. Worth an on-device confirm on a video that previously misbehaved. (If a stream genuinely reports no duration at all — e.g. a live source — resume still can't seek; that's a separate, deeper case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
