### PR TITLE
ci(testflight): build number from latest TestFlight build + 1

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -21,26 +21,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Calculate build number
+      - name: Read app version
         run: |
-          # Read version from pubspec.yaml (e.g., "1.0.0+3" → "1.0.0")
+          # Read version from pubspec.yaml (e.g., "0.1.0+1" -> "0.1.0"). The
+          # build number is queried from TestFlight below (that needs fastlane).
           VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d '+' -f1)
           echo "App version: $VERSION"
-
-          # Find the commit where this version was first set
-          FIRST_COMMIT=$(git log --all --reverse --format='%H' -S "version: $VERSION" -- pubspec.yaml | head -1)
-          if [ -z "$FIRST_COMMIT" ]; then
-            # Version has been there since the beginning
-            BUILD_NUMBER=$(git rev-list --count HEAD)
-          else
-            # Count commits from that point to HEAD (inclusive)
-            BUILD_NUMBER=$(git rev-list --count "$FIRST_COMMIT"..HEAD)
-            BUILD_NUMBER=$((BUILD_NUMBER + 1))
-          fi
-
-          echo "Build number: $BUILD_NUMBER"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-          echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       # App Store Connect requires the iOS 26 SDK (Xcode 26) for uploads
       # as of June 2026.
@@ -64,6 +51,17 @@ jobs:
 
       - name: Install fastlane
         run: sudo gem install fastlane
+
+      - name: Compute next build number from TestFlight
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.APP_STORE_CONNECT_API_KEY_B64 }}
+        run: |
+          # Queries App Store Connect for the latest TestFlight build of this
+          # version and sets BUILD_NUMBER (= latest + 1) in GITHUB_ENV.
+          cd ios
+          fastlane next_build_number
 
       - name: Import signing certificate
         uses: apple-actions/import-codesign-certs@v2

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,18 +1,42 @@
 default_platform(:ios)
 
+APP_IDENTIFIER = "codes.julian.nullfeed"
+
 platform :ios do
-  desc "Upload to TestFlight"
-  lane :beta do
-    api_key = app_store_connect_api_key(
+  # Build the App Store Connect API key object from the CI env vars.
+  private_lane :asc_key do
+    app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
       key_content: ENV["APP_STORE_CONNECT_API_KEY_B64"],
       is_key_content_base64: true,
       in_house: false,
     )
+  end
 
+  desc "Write the next build number (latest TestFlight build + 1) to GITHUB_ENV"
+  lane :next_build_number do
+    latest = latest_testflight_build_number(
+      api_key: asc_key,
+      app_identifier: APP_IDENTIFIER,
+      version: ENV["VERSION"],
+      # Used only when the version train has no builds yet, so the first upload
+      # of a new version starts at build 1.
+      initial_build_number: 0,
+    )
+    next_number = latest + 1
+    UI.important("TestFlight latest build: #{latest} -> next: #{next_number}")
+
+    github_env = ENV["GITHUB_ENV"]
+    if github_env
+      File.open(github_env, "a") { |f| f.puts("BUILD_NUMBER=#{next_number}") }
+    end
+  end
+
+  desc "Upload to TestFlight"
+  lane :beta do
     upload_to_testflight(
-      api_key: api_key,
+      api_key: asc_key,
       ipa: "../build/ios/ipa/nullfeed.ipa",
       skip_waiting_for_build_processing: true,
     )


### PR DESCRIPTION
## Why
The build number was the **commit count on `main`**, so each PR merge added its commits *plus* a merge commit — bumping the number by more than one and leaving gaps (89 → 92 → 94). This switches to the standard "**latest TestFlight build + 1**" approach so it increments by exactly one per upload.

## How
- **Fastfile**: new `next_build_number` lane calls `latest_testflight_build_number` and writes `BUILD_NUMBER = latest + 1` to `$GITHUB_ENV`. The App Store Connect API key setup is factored into a shared `asc_key` private lane (reused by `beta`).
- **testflight.yml**: reads the app version early, then computes the build number via fastlane *after* fastlane is installed and *before* `flutter build ipa` bakes it in.

No new secrets — it reuses the existing `APP_STORE_CONNECT_*` ones.

## Testing / rollout note
`testflight.yml` runs on **push to `main`** (and `workflow_dispatch`), **not on PRs** — so this can't be exercised by this PR's checks. Validated locally: Fastfile passes `ruby -c`, the workflow is valid YAML, and the step order is correct (version → fastlane → build number → build).

It first executes when merged (next upload should be **95** = 94 + 1). If the App Store Connect query ever hiccups, the run fails safely (no upload, existing builds untouched) rather than shipping a wrong number — just re-run. You can also trigger it manually via **Actions → testflight → Run workflow** to confirm before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
