### PR TITLE
fix(player): stop the sponsor-skip seek storm that froze/crashed playback

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -809,7 +809,11 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     // fight the swap's own seek — the "finished caching" freeze.
     if (_switchingToHq) return;
     final pos = player.position.inMilliseconds / 1000.0;
-    final decision = sponsorSkipDecision(pos, _adSegments, _skipSeekInFlightEnd);
+    final decision = sponsorSkipDecision(
+      pos,
+      _adSegments,
+      _skipSeekInFlightEnd,
+    );
     _skipSeekInFlightEnd = decision.inFlightEnd;
     final target = decision.seekToMs;
     if (target != null) {

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -65,6 +65,13 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   bool _showSkipToast = false;
   Timer? _skipToastTimer;
 
+  /// End (seconds) of the sponsor segment whose skip-seek has been issued but
+  /// hasn't landed yet. Guards [_maybeSkipAd] against re-issuing `seekTo` on
+  /// every playback tick while a from-cold seek is still buffering — that seek
+  /// storm livelocks the player (stutter → freeze → crash). Cleared once the
+  /// playhead lands past the segment. See [sponsorSkipDecision].
+  double? _skipSeekInFlightEnd;
+
   /// Set once auto-advance has fired so a stream of post-completion ticks can't
   /// trigger it again.
   bool _advancing = false;
@@ -676,6 +683,10 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
 
       if (!mounted) return;
 
+      // Any skip-seek issued against the preview source is void now that the HQ
+      // source is in place — clear the guard so a sponsor the playhead is still
+      // sitting in gets skipped once on the new source.
+      _skipSeekInFlightEnd = null;
       _hqPollTimer?.cancel();
       _hqPollTimer = null;
       setState(() => _isPreviewMode = false);
@@ -784,18 +795,26 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   }
 
   /// Seek past any sponsor segment the playhead has entered, flashing a brief
-  /// "Skipped sponsor" toast. The 0.5s tail margin stops a seek to a segment's
-  /// end from immediately re-triggering the same segment.
+  /// "Skipped sponsor" toast. Issues the skip-seek at most once per segment (via
+  /// [sponsorSkipDecision]) rather than every tick: on a slow-to-buffer preview
+  /// / instant stream, re-seeking each tick while the first seek is still
+  /// buffering restarts it endlessly and livelocks the player (slow-motion →
+  /// freeze → crash) — which a sponsor at the very start of a video triggers.
   void _maybeSkipAd() {
     final player = _player;
     if (player == null || _adSegments.isEmpty) return;
+    // Stand down during the HQ swap: setResolution reinitializes the source in
+    // place (its position momentarily reads 0) and re-seeks to the restored
+    // spot, so a skip-seek here would fire on a fresh, unbuffered source and
+    // fight the swap's own seek — the "finished caching" freeze.
+    if (_switchingToHq) return;
     final pos = player.position.inMilliseconds / 1000.0;
-    for (final seg in _adSegments) {
-      if (pos >= seg.start && pos < seg.end - 0.5) {
-        player.seekTo(Duration(milliseconds: (seg.end * 1000).round()));
-        _flashSkipToast();
-        break;
-      }
+    final decision = sponsorSkipDecision(pos, _adSegments, _skipSeekInFlightEnd);
+    _skipSeekInFlightEnd = decision.inFlightEnd;
+    final target = decision.seekToMs;
+    if (target != null) {
+      player.seekTo(Duration(milliseconds: target));
+      _flashSkipToast();
     }
   }
 
@@ -1184,6 +1203,45 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       ),
     );
   }
+}
+
+/// Pure decision for the sponsor-skip guard, extracted so its anti-seek-storm
+/// behavior is unit-testable without a live player.
+///
+/// Given the playhead [posSeconds], the detected [segments], and the end
+/// (seconds) of a segment whose skip-seek is already in flight ([inFlightEnd]),
+/// returns the seek target in milliseconds to issue (null when nothing should be
+/// sought) and the in-flight end to remember for the next tick.
+///
+/// The in-flight end is the crux: while a skip-seek is still buffering, the
+/// playhead keeps reporting a position inside the segment, so without this the
+/// caller would re-issue `seekTo` on every tick. Each re-seek cancels and
+/// restarts the native seek, so on a slow-to-buffer source it never lands and
+/// the player livelocks. Issue the seek once, then wait for the playhead to
+/// actually land past the segment before considering another skip.
+@visibleForTesting
+({int? seekToMs, double? inFlightEnd}) sponsorSkipDecision(
+  double posSeconds,
+  List<({double start, double end})> segments,
+  double? inFlightEnd,
+) {
+  // The playhead landed past the segment we were skipping — drop the guard so a
+  // later segment is free to skip.
+  if (inFlightEnd != null && posSeconds >= inFlightEnd - 0.5) {
+    inFlightEnd = null;
+  }
+  for (final seg in segments) {
+    // The 0.5s tail keeps a seek that lands a hair short of the end from
+    // immediately re-triggering the same segment.
+    if (posSeconds >= seg.start && posSeconds < seg.end - 0.5) {
+      // This segment's skip is already in flight — hold, don't storm the seek.
+      if (inFlightEnd == seg.end) {
+        return (seekToMs: null, inFlightEnd: inFlightEnd);
+      }
+      return (seekToMs: (seg.end * 1000).round(), inFlightEnd: seg.end);
+    }
+  }
+  return (seekToMs: null, inFlightEnd: inFlightEnd);
 }
 
 /// Formats a playback timestamp as M:SS, or H:MM:SS once it crosses an hour.

--- a/test/unit/sponsor_skip_test.dart
+++ b/test/unit/sponsor_skip_test.dart
@@ -19,18 +19,21 @@ void main() {
       expect(d.inFlightEnd, 30.0);
     });
 
-    test('a stuck playhead yields exactly one seek over many ticks (no storm)', () {
-      // This is the regression guard: a start sponsor whose seek can't land yet
-      // (unbuffered instant/preview source) must not fire seekTo every tick.
-      double? inFlight;
-      var seeks = 0;
-      for (var tick = 0; tick < 100; tick++) {
-        final d = sponsorSkipDecision(0.1, const [startSponsor], inFlight);
-        inFlight = d.inFlightEnd;
-        if (d.seekToMs != null) seeks++;
-      }
-      expect(seeks, 1);
-    });
+    test(
+      'a stuck playhead yields exactly one seek over many ticks (no storm)',
+      () {
+        // This is the regression guard: a start sponsor whose seek can't land yet
+        // (unbuffered instant/preview source) must not fire seekTo every tick.
+        double? inFlight;
+        var seeks = 0;
+        for (var tick = 0; tick < 100; tick++) {
+          final d = sponsorSkipDecision(0.1, const [startSponsor], inFlight);
+          inFlight = d.inFlightEnd;
+          if (d.seekToMs != null) seeks++;
+        }
+        expect(seeks, 1);
+      },
+    );
 
     test('clears the guard once the playhead lands past the segment', () {
       final d = sponsorSkipDecision(30.0, const [startSponsor], 30.0);

--- a/test/unit/sponsor_skip_test.dart
+++ b/test/unit/sponsor_skip_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/screens/video_player_screen.dart';
+
+void main() {
+  group('sponsorSkipDecision', () {
+    const startSponsor = (start: 0.0, end: 30.0);
+
+    test('seeks to the segment end on first entry', () {
+      final d = sponsorSkipDecision(0.0, const [startSponsor], null);
+      expect(d.seekToMs, 30000);
+      expect(d.inFlightEnd, 30.0);
+    });
+
+    test('does not re-issue the seek while the same skip is in flight', () {
+      // Playhead still stuck inside the segment (the seek is still buffering) —
+      // the guard must return null so the caller does not storm seekTo.
+      final d = sponsorSkipDecision(0.2, const [startSponsor], 30.0);
+      expect(d.seekToMs, isNull);
+      expect(d.inFlightEnd, 30.0);
+    });
+
+    test('a stuck playhead yields exactly one seek over many ticks (no storm)', () {
+      // This is the regression guard: a start sponsor whose seek can't land yet
+      // (unbuffered instant/preview source) must not fire seekTo every tick.
+      double? inFlight;
+      var seeks = 0;
+      for (var tick = 0; tick < 100; tick++) {
+        final d = sponsorSkipDecision(0.1, const [startSponsor], inFlight);
+        inFlight = d.inFlightEnd;
+        if (d.seekToMs != null) seeks++;
+      }
+      expect(seeks, 1);
+    });
+
+    test('clears the guard once the playhead lands past the segment', () {
+      final d = sponsorSkipDecision(30.0, const [startSponsor], 30.0);
+      expect(d.seekToMs, isNull);
+      expect(d.inFlightEnd, isNull);
+    });
+
+    test('skips a later segment after passing an earlier one', () {
+      const segs = [(start: 0.0, end: 30.0), (start: 60.0, end: 75.0)];
+      // Landed past the first segment: the guard clears and nothing new seeks.
+      final past = sponsorSkipDecision(30.0, segs, 30.0);
+      expect(past.seekToMs, isNull);
+      expect(past.inFlightEnd, isNull);
+      // Entering the second segment skips it.
+      final second = sponsorSkipDecision(60.0, segs, past.inFlightEnd);
+      expect(second.seekToMs, 75000);
+      expect(second.inFlightEnd, 75.0);
+    });
+
+    test('chains directly into an adjacent segment', () {
+      const segs = [(start: 0.0, end: 30.0), (start: 30.0, end: 45.0)];
+      // The first skip lands at 30.0, which is the start of the next segment;
+      // the same tick must skip straight into it.
+      final d = sponsorSkipDecision(30.0, segs, 30.0);
+      expect(d.seekToMs, 45000);
+      expect(d.inFlightEnd, 45.0);
+    });
+
+    test('no seek when the playhead is outside every segment', () {
+      final d = sponsorSkipDecision(45.0, const [startSponsor], null);
+      expect(d.seekToMs, isNull);
+      expect(d.inFlightEnd, isNull);
+    });
+
+    test('respects the 0.5s tail margin near the segment end', () {
+      // Inside the last 0.5s of the segment — let it play out, no seek.
+      final d = sponsorSkipDecision(29.6, const [startSponsor], null);
+      expect(d.seekToMs, isNull);
+    });
+
+    test('no segments means no decision', () {
+      final d = sponsorSkipDecision(
+        10.0,
+        const <({double start, double end})>[],
+        null,
+      );
+      expect(d.seekToMs, isNull);
+      expect(d.inFlightEnd, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## The bug

A video that **starts with a sponsor segment** showed the "Skipped sponsor" toast but, instead of skipping, played in slow motion, froze, and crashed. Reported triggers: a sponsor at the start, encountering a sponsor mid-seek, and a video finishing caching mid-playback.

## Root cause — a seek storm

`_onPlayerUpdate` fires on **every** player tick and calls `_maybeSkipAd()`, which had no guard against re-issuing the skip:

```dart
if (pos >= seg.start && pos < seg.end - 0.5) {
  player.seekTo(Duration(milliseconds: (seg.end * 1000).round())); // every tick
```

For a sponsor at the **start** (`[0, ~30s]`), skipping seeks from ~0 to 30s across a region the slow-buffering preview/instant-stream source hasn't buffered yet. The seek can't land before the next tick fires another `seekTo`, which cancels and restarts it — so the playhead never advances, the condition stays true forever, and it re-seeks dozens of times/sec. The native player livelocks: **slow-motion → freeze → crash.**

Why it recently got bad:
- **Instant-playback** made the first source a slow-buffering stream (before, a complete file made seek(30s) land instantly).
- **#64 (better_player_plus)** doesn't coalesce rapid seeks the way `video_player` did. The **web** `switchSource` builds a pre-seeked controller off to the side, so this is **iOS-only**.

The **"finished caching"** trigger is the same root: the HQ swap (`setResolution`) reinitializes the source in place — position momentarily reads 0 while the tick listener keeps firing — so the skip fired on a fresh, unbuffered source and fought the swap's own restore-seek.

> Note: this is a distinct bug from #67/#68 (skip-forward auto-advance via a seek-induced `finished`). Those never touched `_maybeSkipAd`, which is why the crash persisted.

## The fix

1. **Issue the skip-seek once per segment**, then wait for the playhead to actually land past it — extracted into a pure `sponsorSkipDecision(...)` so the anti-storm behavior is unit-testable.
2. **Stand down during the HQ swap** (`if (_switchingToHq) return;`) — kills the "finished caching" collision.
3. **Clear the in-flight guard on source swap**, so a sponsor the playhead is still sitting in gets skipped once on the new HQ source.

## Testing

- New `test/unit/sponsor_skip_test.dart` — the key case: **100 ticks stuck inside a start sponsor → exactly 1 seek** (pre-fix: 100). Plus guard-clear, chained/adjacent segments, tail margin, and no-op cases.
- `flutter analyze --fatal-infos --fatal-warnings` clean.
- **173 tests pass** (was 164).

**On-device check worth doing:** play a video that opens with a sponsor → it should buffer briefly then resume past the sponsor, never stutter/freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
