### PR TITLE
fix(player): don't fight a manual scrub through a sponsor with auto-skip

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -72,6 +72,11 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   /// playhead lands past the segment. See [sponsorSkipDecision].
   double? _skipSeekInFlightEnd;
 
+  /// True while the viewer is actively dragging the seek bar. Suspends sponsor
+  /// auto-skip so a manual scrub through a sponsor segment isn't fought by an
+  /// auto-seek — competing seeks on a still-buffering source wedge the player.
+  bool _isScrubbing = false;
+
   /// Set once auto-advance has fired so a stream of post-completion ticks can't
   /// trigger it again.
   bool _advancing = false;
@@ -803,11 +808,12 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   void _maybeSkipAd() {
     final player = _player;
     if (player == null || _adSegments.isEmpty) return;
-    // Stand down during the HQ swap: setResolution reinitializes the source in
-    // place (its position momentarily reads 0) and re-seeks to the restored
-    // spot, so a skip-seek here would fire on a fresh, unbuffered source and
-    // fight the swap's own seek — the "finished caching" freeze.
-    if (_switchingToHq) return;
+    // Stand down while the viewer is scrubbing (a manual drag through a sponsor
+    // mustn't be fought by an auto-seek — competing seeks wedge the player), and
+    // during the HQ swap: setResolution reinitializes the source in place (its
+    // position momentarily reads 0) and re-seeks to the restored spot, so a
+    // skip-seek there fights the swap's own seek — the "finished caching" freeze.
+    if (_isScrubbing || _switchingToHq) return;
     final pos = player.position.inMilliseconds / 1000.0;
     final decision = sponsorSkipDecision(
       pos,
@@ -862,6 +868,18 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _skipToastTimer = Timer(const Duration(seconds: 2), () {
       if (mounted) setState(() => _showSkipToast = false);
     });
+  }
+
+  /// The viewer grabbed the seek bar — suspend sponsor auto-skip until they
+  /// let go so a manual scrub through a sponsor isn't fought by an auto-seek.
+  void _onScrubStart() => _isScrubbing = true;
+
+  /// The viewer released the seek bar. Resume auto-skip and drop any in-flight
+  /// skip guard: a manual reposition voids the prior seek, so a sponsor the
+  /// viewer landed inside is skipped once, fresh, from the released position.
+  void _onScrubEnd() {
+    _isScrubbing = false;
+    _skipSeekInFlightEnd = null;
   }
 
   /// When the video plays through to the end, advance into the queue: consume
@@ -1145,6 +1163,8 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
                   player: _player!,
                   onBack: _navigateBack,
                   onSeekRelative: _seekRelative,
+                  onSeekStart: _onScrubStart,
+                  onSeekEnd: _onScrubEnd,
                   onPlayPause: _togglePlayPause,
                   onInteraction: _scheduleHideControls,
                   isQueued: isQueued,
@@ -1319,6 +1339,11 @@ class _ControlsOverlay extends StatelessWidget {
   final NfPlaybackController player;
   final VoidCallback onBack;
   final void Function(int) onSeekRelative;
+
+  /// Called when the viewer begins / ends dragging the seek bar, so the screen
+  /// can suspend sponsor auto-skip during a manual scrub.
+  final VoidCallback onSeekStart;
+  final VoidCallback onSeekEnd;
   final VoidCallback onPlayPause;
   final VoidCallback onInteraction;
 
@@ -1340,6 +1365,8 @@ class _ControlsOverlay extends StatelessWidget {
     required this.player,
     required this.onBack,
     required this.onSeekRelative,
+    required this.onSeekStart,
+    required this.onSeekEnd,
     required this.onPlayPause,
     required this.onInteraction,
     required this.isFullscreen,
@@ -1505,6 +1532,8 @@ class _ControlsOverlay extends StatelessWidget {
                           player.seekTo(target);
                           onInteraction();
                         },
+                        onSeekStart: onSeekStart,
+                        onSeekEnd: onSeekEnd,
                       ),
                       const SizedBox(height: 4),
                       Row(

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -8,6 +8,12 @@ class NullFeedProgressBar extends StatelessWidget {
   final Color? backgroundColor;
   final void Function(double)? onSeek;
 
+  /// Called when the viewer begins / ends dragging the seek bar. Lets the
+  /// player suspend sponsor auto-skip during a manual scrub so a drag through a
+  /// sponsor segment isn't fought by an auto-seek. Only used when [onSeek] is set.
+  final VoidCallback? onSeekStart;
+  final VoidCallback? onSeekEnd;
+
   /// Accessibility label for the seek slider. Only used when [onSeek] is set.
   final String? semanticLabel;
 
@@ -23,6 +29,8 @@ class NullFeedProgressBar extends StatelessWidget {
     this.foregroundColor,
     this.backgroundColor,
     this.onSeek,
+    this.onSeekStart,
+    this.onSeekEnd,
     this.semanticLabel,
     this.semanticValueBuilder,
   });
@@ -71,6 +79,7 @@ class NullFeedProgressBar extends StatelessWidget {
               seek(fraction);
             }
           },
+          onHorizontalDragStart: (_) => onSeekStart?.call(),
           onHorizontalDragUpdate: (details) {
             final box = context.findRenderObject() as RenderBox?;
             if (box != null) {
@@ -79,6 +88,8 @@ class NullFeedProgressBar extends StatelessWidget {
               seek(fraction);
             }
           },
+          onHorizontalDragEnd: (_) => onSeekEnd?.call(),
+          onHorizontalDragCancel: () => onSeekEnd?.call(),
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),
             child: bar,


### PR DESCRIPTION
## The bug

Dragging the seek bar **through a sponsor segment** could freeze the player and eventually close the video.

`onHorizontalDragUpdate` fires a continuous stream of `seekTo` calls while you drag. When the playhead passes into a sponsor segment, `_maybeSkipAd` (running every tick) injected its **own** `seekTo(segment end)` into that stream — two seek sources competing on a still-buffering preview/instant source wedged the player. It's a race, so it reproduces off a buffering source and is intermittent (a fully-cached video drags smoothly).

## The fix

Auto-skip shouldn't fight a deliberate manual scrub. The seek bar now reports scrub **start/end** (`onHorizontalDragStart` / `onHorizontalDragEnd` / `onHorizontalDragCancel`), and `_maybeSkipAd` stands down while `_isScrubbing` — same shape as the existing `_switchingToHq` stand-down. On release it clears the in-flight skip guard so it re-evaluates fresh from where the playhead was dropped: a sponsor the viewer lands in is still skipped once, cleanly, with no competing drag.

Follow-up to the sponsor-skip seek-storm fix (#70).

## Testing

- `flutter analyze --fatal-infos --fatal-warnings` clean; 173 tests pass (the pure `sponsorSkipDecision` tests are unaffected — the scrub gate lives in the impure `_maybeSkipAd`).
- **On-device check:** drag the scrubber back and forth across a pre-roll sponsor while it's still on the preview stream — should stay smooth, no freeze; releasing inside the sponsor still skips past it once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
