### PR TITLE
feat(content-type): badge video types + per-channel filter menu

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -66,6 +66,8 @@ class AppConstants {
   static String authProfile(String id) => '$apiBase/auth/profiles/$id';
   static String channelDetail(String id) => '$apiBase/channels/$id';
   static String channelVideos(String id) => '$apiBase/channels/$id/videos';
+  static String channelContentFilter(String id) =>
+      '$apiBase/channels/$id/content-filter';
   static String channelPoll(String id) => '$apiBase/channels/$id/poll';
   static String channelRefreshImages(String id) =>
       '$apiBase/channels/$id/refresh-images';

--- a/lib/models/channel.dart
+++ b/lib/models/channel.dart
@@ -17,6 +17,16 @@ abstract class Channel with _$Channel {
     @JsonKey(name: 'last_checked_at', fromJson: nullableDateTimeFromJson)
     DateTime? lastCheckedAt,
     @JsonKey(name: 'tracking_mode') String? trackingMode,
+    @JsonKey(name: 'is_subscribed') @Default(false) bool isSubscribed,
+    // Content types (wire values, e.g. 'short') this user has hidden for this
+    // channel, and the distinct types the channel actually has — together they
+    // drive the per-channel filter menu.
+    @JsonKey(name: 'hidden_content_types')
+    @Default(<String>[])
+    List<String> hiddenContentTypes,
+    @JsonKey(name: 'available_content_types')
+    @Default(<String>[])
+    List<String> availableContentTypes,
   }) = _Channel;
 
   factory Channel.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/video.dart
+++ b/lib/models/video.dart
@@ -81,6 +81,80 @@ extension UnplayableReasonLabels on UnplayableReason {
   };
 }
 
+/// What kind of media a video is, classified by the backend at catalog time. A
+/// stable label (unlike [UnplayableReason], which clears once playable), used to
+/// badge the thumbnail and drive the per-channel filter. Null/[regular] is a
+/// plain upload; [unknown] absorbs vocabulary the backend adds before this
+/// client learns it.
+enum ContentType {
+  @JsonValue('regular')
+  regular,
+  @JsonValue('short')
+  short,
+  @JsonValue('live')
+  live,
+  @JsonValue('premiere')
+  premiere,
+  @JsonValue('age_restricted')
+  ageRestricted,
+  @JsonValue('members_only')
+  membersOnly,
+  @JsonValue('premium')
+  premium,
+  unknown,
+}
+
+extension ContentTypeLabels on ContentType {
+  /// Short thumbnail-badge text (singular).
+  String get label => switch (this) {
+    ContentType.short => 'Short',
+    ContentType.live => 'Live',
+    ContentType.premiere => 'Premiere',
+    ContentType.ageRestricted => 'Age-restricted',
+    ContentType.membersOnly => 'Members only',
+    ContentType.premium => 'Premium',
+    ContentType.regular || ContentType.unknown => '',
+  };
+
+  /// Filter-menu label (plural where natural).
+  String get menuLabel => switch (this) {
+    ContentType.regular => 'Videos',
+    ContentType.short => 'Shorts',
+    ContentType.live => 'Live',
+    ContentType.premiere => 'Premieres',
+    ContentType.ageRestricted => 'Age-restricted',
+    ContentType.membersOnly => 'Members only',
+    ContentType.premium => 'Premium',
+    ContentType.unknown => 'Other',
+  };
+
+  /// The backend wire value (matches the @JsonValue), for the filter API and
+  /// comparing against a channel's hidden/available lists.
+  String get wire => switch (this) {
+    ContentType.regular => 'regular',
+    ContentType.short => 'short',
+    ContentType.live => 'live',
+    ContentType.premiere => 'premiere',
+    ContentType.ageRestricted => 'age_restricted',
+    ContentType.membersOnly => 'members_only',
+    ContentType.premium => 'premium',
+    ContentType.unknown => 'unknown',
+  };
+}
+
+/// Parse a backend content-type wire value (e.g. from a channel's
+/// available/hidden lists) into a [ContentType], or null if unrecognized.
+ContentType? contentTypeFromWire(String value) => switch (value) {
+  'regular' => ContentType.regular,
+  'short' => ContentType.short,
+  'live' => ContentType.live,
+  'premiere' => ContentType.premiere,
+  'age_restricted' => ContentType.ageRestricted,
+  'members_only' => ContentType.membersOnly,
+  'premium' => ContentType.premium,
+  _ => null,
+};
+
 @freezed
 abstract class Video with _$Video {
   const factory Video({
@@ -110,6 +184,9 @@ abstract class Video with _$Video {
       unknownEnumValue: UnplayableReason.unknown,
     )
     UnplayableReason? unplayableReason,
+    // What kind of media this is (see ContentType); null = regular.
+    @JsonKey(name: 'content_type', unknownEnumValue: ContentType.unknown)
+    ContentType? contentType,
     // Joined from channel
     @JsonKey(name: 'channel_name') @Default('') String channelName,
   }) = _Video;
@@ -129,6 +206,18 @@ extension VideoExtensions on Video {
   /// file for (HQ or preview) plays regardless of a stale label, so no banner.
   UnplayableReason? get activeUnplayableReason =>
       isPlayable ? null : unplayableReason;
+
+  /// The content type worth badging on the thumbnail, or null. Regular/unknown
+  /// aren't badged, and the unplayable banner already covers members/premium/
+  /// age when it's showing — so the two badges never stack.
+  ContentType? get badgeContentType {
+    if (activeUnplayableReason != null) return null;
+    final ct = contentType;
+    if (ct == null || ct == ContentType.regular || ct == ContentType.unknown) {
+      return null;
+    }
+    return ct;
+  }
 
   bool get hasPreviewReady => previewStatus == 'READY';
 

--- a/lib/screens/channel_detail_screen.dart
+++ b/lib/screens/channel_detail_screen.dart
@@ -7,6 +7,8 @@ import '../providers/channel_provider.dart';
 import '../providers/feed_provider.dart';
 import '../services/api_service.dart';
 import '../services/storage_service.dart';
+import '../models/channel.dart';
+import '../widgets/content_type_badge.dart';
 import '../widgets/queue_action.dart';
 import '../widgets/unplayable_badge.dart';
 import '../widgets/video_list_tile.dart';
@@ -146,6 +148,21 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
                 expandedHeight: 220,
                 pinned: true,
                 backgroundColor: NullFeedTheme.surfaceColor,
+                actions: [
+                  // Per-channel content-type filter — only when subscribed and
+                  // the channel has more than one kind of media to sift.
+                  if (channel.isSubscribed &&
+                      channel.availableContentTypes.length > 1)
+                    IconButton(
+                      icon: Icon(
+                        channel.hiddenContentTypes.isEmpty
+                            ? Icons.filter_alt_outlined
+                            : Icons.filter_alt,
+                      ),
+                      tooltip: 'Filter content types',
+                      onPressed: () => _showContentFilter(channel),
+                    ),
+                ],
                 flexibleSpace: FlexibleSpaceBar(
                   background: Stack(
                     fit: StackFit.expand,
@@ -401,6 +418,89 @@ class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
         ),
       ),
     );
+  }
+
+  /// The per-channel content-type filter menu: a checklist of the types this
+  /// channel has. Unchecking a type hides it from this channel's list and feeds
+  /// (persisted server-side); checking it brings it back. Toggles apply live.
+  void _showContentFilter(Channel channel) {
+    final available = channel.availableContentTypes
+        .map(contentTypeFromWire)
+        .whereType<ContentType>()
+        .where((t) => t != ContentType.unknown)
+        .toList();
+    if (available.isEmpty) return;
+
+    // Local source of truth for the sheet, seeded from the current filter and
+    // updated optimistically so toggles feel instant; each change is persisted.
+    final hidden = {...channel.hiddenContentTypes};
+
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: NullFeedTheme.cardColor,
+      builder: (sheetContext) => StatefulBuilder(
+        builder: (context, setSheetState) => SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 16, 16, 4),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'Show content types',
+                    style: TextStyle(
+                      color: NullFeedTheme.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+              for (final type in available)
+                CheckboxListTile(
+                  value: !hidden.contains(type.wire),
+                  secondary: Icon(
+                    contentTypeIcon(type),
+                    color: contentTypeColor(type),
+                  ),
+                  title: Text(type.menuLabel),
+                  activeColor: NullFeedTheme.primaryColor,
+                  onChanged: (show) {
+                    setSheetState(() {
+                      if (show == false) {
+                        hidden.add(type.wire);
+                      } else {
+                        hidden.remove(type.wire);
+                      }
+                    });
+                    _applyContentFilter(hidden.toList());
+                  },
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _applyContentFilter(List<String> hidden) async {
+    try {
+      await ref
+          .read(apiServiceProvider)
+          .setContentFilter(widget.channelId, hidden);
+      if (!mounted) return;
+      // Re-fetch the channel (updated filter + icon state) and the now-gated
+      // video list.
+      ref.invalidate(channelDetailProvider(widget.channelId));
+      ref.invalidate(channelVideosProvider(widget.channelId));
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Couldn\'t update the filter')),
+        );
+      }
+    }
   }
 
   void _showVideoMenu(Video video) {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -341,6 +341,19 @@ class ApiService {
         .toList();
   });
 
+  /// Replaces the content types hidden for [channelId] (the per-channel filter).
+  /// Returns the updated channel. An empty list clears the filter.
+  Future<Channel> setContentFilter(
+    String channelId,
+    List<String> hiddenContentTypes,
+  ) => _guard(() async {
+    final response = await _dio.put(
+      '$_baseUrl${AppConstants.channelContentFilter(channelId)}',
+      data: {'hidden_content_types': hiddenContentTypes},
+    );
+    return Channel.fromJson(response.data as Map<String, dynamic>);
+  });
+
   Future<void> subscribeToChannel(
     String youtubeUrl, {
     String trackingMode = 'FUTURE_ONLY',

--- a/lib/widgets/content_type_badge.dart
+++ b/lib/widgets/content_type_badge.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import '../config/theme.dart';
+import '../models/video.dart';
+
+/// Per-type accent for [ContentTypeBadge]. The chip keeps the shared black
+/// background so it reads like the other thumbnail badges; the icon carries the
+/// color. Reuses the unplayable-badge colors where types overlap.
+Color contentTypeColor(ContentType type) => switch (type) {
+  ContentType.short => NullFeedTheme.primaryColor,
+  ContentType.live => NullFeedTheme.errorColor,
+  ContentType.premiere => const Color(0xFF4DB6AC),
+  ContentType.ageRestricted => NullFeedTheme.errorColor,
+  ContentType.membersOnly => const Color(0xFFFFB74D),
+  ContentType.premium => NullFeedTheme.primaryColor,
+  ContentType.regular || ContentType.unknown => NullFeedTheme.textMuted,
+};
+
+IconData contentTypeIcon(ContentType type) => switch (type) {
+  ContentType.short => Icons.smart_display,
+  ContentType.live => Icons.sensors,
+  ContentType.premiere => Icons.schedule,
+  ContentType.ageRestricted => Icons.explicit,
+  ContentType.membersOnly => Icons.card_membership,
+  ContentType.premium => Icons.workspace_premium,
+  ContentType.regular || ContentType.unknown => Icons.videocam,
+};
+
+/// Thumbnail pill marking a video's content type (Short, Live, Premiere, …).
+/// Sits in a tile's thumbnail [Stack]; [compact] shrinks it for the small
+/// list-tile thumbnails. Mirrors [UnplayableBadge] — the two never show at once
+/// (see [VideoExtensions.badgeContentType]).
+class ContentTypeBadge extends StatelessWidget {
+  final ContentType type;
+  final bool compact;
+
+  const ContentTypeBadge({super.key, required this.type, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final iconSize = compact ? 10.0 : 12.0;
+    final fontSize = compact ? 9.0 : 10.0;
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: compact ? 4 : 6,
+        vertical: compact ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.8),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            contentTypeIcon(type),
+            color: contentTypeColor(type),
+            size: iconSize,
+          ),
+          SizedBox(width: compact ? 3 : 4),
+          Text(
+            type.label,
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: fontSize,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/video_card.dart
+++ b/lib/widgets/video_card.dart
@@ -9,6 +9,7 @@ import '../config/theme.dart';
 import '../config/constants.dart';
 import '../providers/feed_provider.dart';
 import '../providers/offline_provider.dart';
+import 'content_type_badge.dart';
 import 'progress_bar.dart';
 import 'queue_action.dart';
 import 'unplayable_badge.dart';
@@ -150,7 +151,9 @@ class _VideoCardState extends ConsumerState<VideoCard> {
 
                               // Why this video can't play (age-restricted,
                               // members-only, …) — hidden once a local file
-                              // makes it playable anyway.
+                              // makes it playable anyway. Otherwise the
+                              // content-type pill (Short/Live/…) takes the same
+                              // corner; the two never show together.
                               if (widget.video.activeUnplayableReason != null)
                                 Positioned(
                                   left: 6,
@@ -158,6 +161,14 @@ class _VideoCardState extends ConsumerState<VideoCard> {
                                   child: UnplayableBadge(
                                     reason:
                                         widget.video.activeUnplayableReason!,
+                                  ),
+                                )
+                              else if (widget.video.badgeContentType != null)
+                                Positioned(
+                                  left: 6,
+                                  top: 6,
+                                  child: ContentTypeBadge(
+                                    type: widget.video.badgeContentType!,
                                   ),
                                 ),
 

--- a/lib/widgets/video_list_tile.dart
+++ b/lib/widgets/video_list_tile.dart
@@ -8,6 +8,7 @@ import '../models/video.dart';
 import '../config/theme.dart';
 import '../providers/offline_provider.dart';
 import '../services/offline_service.dart';
+import 'content_type_badge.dart';
 import 'progress_bar.dart';
 import 'unplayable_badge.dart';
 
@@ -205,7 +206,9 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
                                     ),
                                   ),
                                 // Why this video can't play — hidden once a
-                                // local file makes it playable anyway.
+                                // local file makes it playable anyway. Otherwise
+                                // the content-type pill (Short/Live/…) shares the
+                                // same corner; they never show together.
                                 if (widget.video.activeUnplayableReason != null)
                                   Positioned(
                                     left: 4,
@@ -213,6 +216,15 @@ class _VideoListTileState extends ConsumerState<VideoListTile> {
                                     child: UnplayableBadge(
                                       reason:
                                           widget.video.activeUnplayableReason!,
+                                      compact: true,
+                                    ),
+                                  )
+                                else if (widget.video.badgeContentType != null)
+                                  Positioned(
+                                    left: 4,
+                                    top: 4,
+                                    child: ContentTypeBadge(
+                                      type: widget.video.badgeContentType!,
                                       compact: true,
                                     ),
                                   ),

--- a/test/unit/models_test.dart
+++ b/test/unit/models_test.dart
@@ -174,6 +174,35 @@ void main() {
     });
   });
 
+  group('Channel', () {
+    test('parses the per-channel content filter fields', () {
+      final channel = Channel.fromJson(const {
+        'id': 'c1',
+        'youtube_channel_id': 'UC1',
+        'name': 'Chan',
+        'slug': 'chan',
+        'is_subscribed': true,
+        'hidden_content_types': ['short', 'live'],
+        'available_content_types': ['regular', 'short', 'live'],
+      });
+      expect(channel.isSubscribed, isTrue);
+      expect(channel.hiddenContentTypes, ['short', 'live']);
+      expect(channel.availableContentTypes, ['regular', 'short', 'live']);
+    });
+
+    test('defaults the filter fields when absent', () {
+      final channel = Channel.fromJson(const {
+        'id': 'c1',
+        'youtube_channel_id': 'UC1',
+        'name': 'Chan',
+        'slug': 'chan',
+      });
+      expect(channel.isSubscribed, isFalse);
+      expect(channel.hiddenContentTypes, isEmpty);
+      expect(channel.availableContentTypes, isEmpty);
+    });
+  });
+
   group('Video', () {
     test('parses a naive uploaded_at as UTC and maps the status enum', () {
       final video = Video.fromJson(const {
@@ -217,6 +246,67 @@ void main() {
       expect(video.unplayableReason, UnplayableReason.membersOnly);
       expect(video.activeUnplayableReason, UnplayableReason.membersOnly);
       expect(Video.fromJson(video.toJson()), video);
+    });
+
+    test('maps content_type and computes the badge type', () {
+      final short = Video.fromJson(const {
+        'id': 'v1',
+        'youtube_video_id': 'yt1',
+        'channel_id': 'c1',
+        'title': 'A Short',
+        'content_type': 'short',
+      });
+      expect(short.contentType, ContentType.short);
+      expect(short.badgeContentType, ContentType.short);
+      expect(Video.fromJson(short.toJson()), short);
+    });
+
+    test('regular / null / unknown content types are not badged', () {
+      Video withType(String? ct) => Video.fromJson({
+        'id': 'v1',
+        'youtube_video_id': 'yt1',
+        'channel_id': 'c1',
+        'title': 'A Video',
+        if (ct != null) 'content_type': ct,
+      });
+      expect(withType(null).contentType, isNull);
+      expect(withType(null).badgeContentType, isNull);
+      expect(withType('regular').badgeContentType, isNull);
+      // Forward-compat: an unknown type maps to unknown and isn't badged.
+      expect(withType('some_future_type').contentType, ContentType.unknown);
+      expect(withType('some_future_type').badgeContentType, isNull);
+    });
+
+    test(
+      'a playable video still badges its content type (no unplayable ban)',
+      () {
+        // members_only + a ready preview: the video is playable so the unplayable
+        // banner is suppressed, and the content-type pill shows instead.
+        final v = Video.fromJson(const {
+          'id': 'v1',
+          'youtube_video_id': 'yt1',
+          'channel_id': 'c1',
+          'title': 'A Video',
+          'content_type': 'members_only',
+          'unplayable_reason': 'members_only',
+          'preview_status': 'READY',
+        });
+        expect(v.activeUnplayableReason, isNull);
+        expect(v.badgeContentType, ContentType.membersOnly);
+      },
+    );
+
+    test('an active unplayable banner suppresses the content-type badge', () {
+      final v = Video.fromJson(const {
+        'id': 'v1',
+        'youtube_video_id': 'yt1',
+        'channel_id': 'c1',
+        'title': 'A Video',
+        'content_type': 'members_only',
+        'unplayable_reason': 'members_only',
+      });
+      expect(v.activeUnplayableReason, UnplayableReason.membersOnly);
+      expect(v.badgeContentType, isNull);
     });
 
     test(

--- a/test/widgets/content_type_badge_test.dart
+++ b/test/widgets/content_type_badge_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/config/theme.dart';
+import 'package:nullfeed/models/video.dart';
+import 'package:nullfeed/providers/offline_provider.dart';
+import 'package:nullfeed/widgets/content_type_badge.dart';
+import 'package:nullfeed/widgets/unplayable_badge.dart';
+import 'package:nullfeed/widgets/video_card.dart';
+import 'package:nullfeed/widgets/video_list_tile.dart';
+
+Video makeVideo({
+  VideoStatus status = VideoStatus.cataloged,
+  ContentType? contentType,
+  UnplayableReason? unplayableReason,
+  String? previewStatus,
+}) {
+  // youtubeVideoId left blank so the tiles render their placeholder instead of
+  // reaching out for a network thumbnail during the test.
+  return Video(
+    id: 'v1',
+    youtubeVideoId: '',
+    channelId: 'c1',
+    title: 'A Clip',
+    status: status,
+    previewStatus: previewStatus,
+    contentType: contentType,
+    unplayableReason: unplayableReason,
+  );
+}
+
+Future<void> pumpTile(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [offlineStatusProvider('v1').overrideWithValue(null)],
+      child: MaterialApp(
+        theme: NullFeedTheme.darkTheme,
+        home: Scaffold(body: child),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('badge shows the type label and icon', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: ContentTypeBadge(type: ContentType.live)),
+      ),
+    );
+
+    expect(find.text('Live'), findsOneWidget);
+    expect(find.byIcon(Icons.sensors), findsOneWidget);
+  });
+
+  testWidgets('video card badges a Short', (tester) async {
+    await pumpTile(
+      tester,
+      VideoCard(video: makeVideo(contentType: ContentType.short)),
+    );
+
+    expect(find.byType(ContentTypeBadge), findsOneWidget);
+    expect(find.text('Short'), findsOneWidget);
+  });
+
+  testWidgets('regular videos are not badged', (tester) async {
+    await pumpTile(
+      tester,
+      VideoCard(video: makeVideo(contentType: ContentType.regular)),
+    );
+
+    expect(find.byType(ContentTypeBadge), findsNothing);
+  });
+
+  testWidgets('the unplayable banner wins over the content-type badge', (
+    tester,
+  ) async {
+    // A not-yet-playable members-only Short: the unplayable banner shows and the
+    // content-type pill is suppressed (they share the corner).
+    await pumpTile(
+      tester,
+      VideoCard(
+        video: makeVideo(
+          contentType: ContentType.short,
+          unplayableReason: UnplayableReason.membersOnly,
+        ),
+      ),
+    );
+
+    expect(find.byType(UnplayableBadge), findsOneWidget);
+    expect(find.byType(ContentTypeBadge), findsNothing);
+  });
+
+  testWidgets('list tile badges compactly', (tester) async {
+    await pumpTile(
+      tester,
+      VideoListTile(
+        video: makeVideo(contentType: ContentType.premiere),
+        onTap: () {},
+      ),
+    );
+
+    final badge = tester.widget<ContentTypeBadge>(
+      find.byType(ContentTypeBadge),
+    );
+    expect(badge.compact, isTrue);
+    expect(find.text('Premiere'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Phase 4 — the Flutter (iOS/web) client for content-type detection + per-channel gating. Surfaces backend #116–120.

## Type badges
A `ContentTypeBadge` pill (icon + label) on each thumbnail marks **Short / Live / Premiere / Age-restricted / Members only / Premium**. Per the design you picked:
- Only **non-regular** types are badged — regular videos stay clean.
- It takes the **top-left status-badge corner**. Since the content type and the unplayable banner are mutually exclusive per video (`Video.badgeContentType` returns null when the unplayable banner is showing), they never stack — placing it where the unplayable badge already lives keeps both card layouts consistent (bottom-left is the offline badge in the grid card).

## Per-channel filter menu
An **app-bar filter icon** on the channel screen (outlined normally, **filled** when a filter is active) opens a **checklist of just the types the channel actually has** (`available_content_types`). Unchecking a type hides it from the channel list and feeds — persisted server-side via `PUT /channels/{id}/content-filter` — and re-fetches the gated list. Only shown when subscribed and the channel has >1 kind of media.

## Changes
- `ContentType` enum + `Video.contentType` + `badgeContentType` helper
- `ContentTypeBadge` widget; wired into `video_card` + `video_list_tile`
- `Channel`: `isSubscribed`, `hiddenContentTypes`, `availableContentTypes`
- `api.setContentFilter`; `channelContentFilter` endpoint constant
- Channel screen: filter icon + live checklist bottom sheet

## Verification
`flutter analyze --fatal-infos --fatal-warnings` clean · **184 tests pass** (+11: badge render + unplayable-wins suppression, `content_type` decode, channel filter-field decode).

**On-device look worth a glance:** open a channel with mixed media → Shorts/Live badges on thumbnails, and the filter icon → checklist. tvOS gets the same treatment next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
