### PR TITLE
Player: fix seek freeze (serialized seeks) + chevron skip controls with hold-to-seek

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -99,6 +99,16 @@ class AppConstants {
   static const int skipForwardSeconds = 10;
   static const int skipBackwardSeconds = 10;
 
+  /// Hold-to-seek: holding a skip control scrubs continuously. The rate starts
+  /// at [holdSeekInitialRate] video-seconds per held second and ramps linearly
+  /// by [holdSeekRampPerSecond] each second, capped at [holdSeekMaxRate].
+  static const double holdSeekInitialRate = 8;
+  static const double holdSeekRampPerSecond = 12;
+  static const double holdSeekMaxRate = 120;
+
+  /// How often the hold-to-seek ticker advances the target position.
+  static const int holdSeekTickMs = 100;
+
   /// How long to wait for a server-side preview/HQ render before giving up and
   /// showing a graceful "taking longer than expected" message instead of an
   /// indefinite spinner.

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -16,6 +16,7 @@ import '../config/constants.dart';
 import '../config/theme.dart';
 import '../widgets/progress_bar.dart';
 import '../widgets/queue_action.dart';
+import '../widgets/skip_control.dart';
 import '../widgets/unplayable_badge.dart';
 
 class VideoPlayerScreen extends ConsumerStatefulWidget {
@@ -76,6 +77,28 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   /// auto-skip so a manual scrub through a sponsor segment isn't fought by an
   /// auto-seek — competing seeks on a still-buffering source wedge the player.
   bool _isScrubbing = false;
+
+  /// The 0–1 fraction under the finger while the seek bar is being dragged;
+  /// null when idle. No seek is issued during the drag — this only lets the
+  /// overlay preview the target timestamp until release commits one seek.
+  double? _scrubPreviewFraction;
+
+  /// Where the playhead should end up once the in-flight native seek lands;
+  /// null when no seek is wanted. All manual seeks funnel through
+  /// [_requestSeek] → [_drainSeeks]: exactly one native `seekTo` is ever
+  /// outstanding, and newer requests coalesce here instead of each firing
+  /// their own. Re-seeking while a seek is still buffering cancels and
+  /// restarts it — storming that wedges the player (stutter → freeze →
+  /// crash), the same failure mode [sponsorSkipDecision] guards against.
+  Duration? _pendingSeekTarget;
+  bool _seekInFlight = false;
+
+  /// Hold-to-seek: +1 / -1 while a skip control is held, 0 when idle.
+  int _holdSeekDirection = 0;
+  Timer? _holdSeekTimer;
+  Duration _holdSeekBase = Duration.zero;
+  double _holdSeekAccumulated = 0;
+  double _holdSeekElapsed = 0;
 
   /// Set once auto-advance has fired so a stream of post-completion ticks can't
   /// trigger it again.
@@ -701,6 +724,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
       debugPrint('HQ switch failed, continuing preview: $e');
     } finally {
       _switchingToHq = false;
+      // A manual seek requested mid-swap was parked (the drain pauses while
+      // the swap owns the player) — issue it now.
+      if (_pendingSeekTarget != null) unawaited(_drainSeeks());
     }
   }
 
@@ -733,6 +759,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   }
 
   void _toggleControls() {
+    // Hiding the overlay would dispose the held skip control mid-gesture and
+    // its release callback with it — end the hold first so the ticker stops.
+    if (_holdSeekDirection != 0) _endHoldSeek();
     setState(() => _showControls = !_showControls);
     if (_showControls) _scheduleHideControls();
   }
@@ -753,7 +782,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   /// banner's "Start over" action.
   void _restartFromStart() {
     _resumeBannerTimer?.cancel();
-    _player?.seekTo(Duration.zero);
+    _requestSeek(Duration.zero);
     setState(() {
       _showResumeBanner = false;
       _showControls = true;
@@ -809,11 +838,18 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     final player = _player;
     if (player == null || _adSegments.isEmpty) return;
     // Stand down while the viewer is scrubbing (a manual drag through a sponsor
-    // mustn't be fought by an auto-seek — competing seeks wedge the player), and
-    // during the HQ swap: setResolution reinitializes the source in place (its
-    // position momentarily reads 0) and re-seeks to the restored spot, so a
-    // skip-seek there fights the swap's own seek — the "finished caching" freeze.
-    if (_isScrubbing || _switchingToHq) return;
+    // mustn't be fought by an auto-seek — competing seeks wedge the player),
+    // while a manual seek is pending or landing (same reason; the playhead the
+    // decision would read is stale anyway), and during the HQ swap:
+    // setResolution reinitializes the source in place (its position
+    // momentarily reads 0) and re-seeks to the restored spot, so a skip-seek
+    // there fights the swap's own seek — the "finished caching" freeze.
+    if (_isScrubbing ||
+        _switchingToHq ||
+        _seekInFlight ||
+        _pendingSeekTarget != null) {
+      return;
+    }
     final pos = player.position.inMilliseconds / 1000.0;
     final decision = sponsorSkipDecision(
       pos,
@@ -823,7 +859,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _skipSeekInFlightEnd = decision.inFlightEnd;
     final target = decision.seekToMs;
     if (target != null) {
-      player.seekTo(Duration(milliseconds: target));
+      _requestSeek(Duration(milliseconds: target), fromAutoSkip: true);
       _flashSkipToast();
     }
   }
@@ -874,12 +910,21 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   /// let go so a manual scrub through a sponsor isn't fought by an auto-seek.
   void _onScrubStart() => _isScrubbing = true;
 
+  /// Live drag position from the seek bar; no seek is issued — this only
+  /// drives the previewed timestamp in the overlay until release.
+  void _onScrubUpdate(double fraction) {
+    setState(() => _scrubPreviewFraction = fraction);
+  }
+
   /// The viewer released the seek bar. Resume auto-skip and drop any in-flight
   /// skip guard: a manual reposition voids the prior seek, so a sponsor the
   /// viewer landed inside is skipped once, fresh, from the released position.
   void _onScrubEnd() {
     _isScrubbing = false;
     _skipSeekInFlightEnd = null;
+    if (_scrubPreviewFraction != null) {
+      setState(() => _scrubPreviewFraction = null);
+    }
   }
 
   /// When the video plays through to the end, advance into the queue: consume
@@ -934,8 +979,24 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   void _seekRelative(int seconds) {
     final player = _player;
     if (player == null) return;
-    var target = player.position + Duration(seconds: seconds);
-    // Never skip onto/past the end. The player reports a seek beyond the
+    // Accumulate from the pending target, not the playhead: while a seek is
+    // still buffering the reported position is stale, so three quick forward
+    // taps must mean +30s, not three re-seeks to the same +10s spot.
+    final base = _pendingSeekTarget ?? player.position;
+    _requestSeek(base + Duration(seconds: seconds));
+    setState(() => _showControls = true);
+    _scheduleHideControls();
+  }
+
+  /// Requests a seek to [target], clamped to the playable range. Every manual
+  /// seek (taps, double-taps, keyboard, scrub release, hold-to-seek) and the
+  /// sponsor auto-skip funnel through here so [_drainSeeks] can keep exactly
+  /// one native seek in flight at a time.
+  void _requestSeek(Duration target, {bool fromAutoSkip = false}) {
+    final player = _player;
+    if (player == null) return;
+    var clamped = target;
+    // Never seek onto/past the end. The player reports a seek beyond the
     // duration as "finished" (video_player flips isCompleted at the end just
     // the same), which would auto-advance to the next queued video instead of
     // just nudging the playhead — so a skip-forward near the end must stay a
@@ -943,12 +1004,103 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     final duration = player.duration;
     if (duration > Duration.zero) {
       final maxTarget = duration - const Duration(seconds: 1);
-      if (target > maxTarget) target = maxTarget;
+      if (clamped > maxTarget) clamped = maxTarget;
     }
-    if (target < Duration.zero) target = Duration.zero;
-    player.seekTo(target);
-    setState(() => _showControls = true);
+    if (clamped < Duration.zero) clamped = Duration.zero;
+    // A manual reposition voids any in-flight sponsor skip-seek, so a sponsor
+    // the viewer lands inside is skipped once, fresh, from the new position.
+    if (!fromAutoSkip) _skipSeekInFlightEnd = null;
+    _pendingSeekTarget = clamped;
+    unawaited(_drainSeeks());
+  }
+
+  /// Issues pending seeks one at a time, waiting for each native seek to land
+  /// before starting the next; requests that arrive mid-seek coalesce into
+  /// [_pendingSeekTarget] and only the newest is issued next. While the HQ
+  /// swap is replacing the source the drain pauses ([_switchToHq] resumes it)
+  /// so a manual seek can't fight the swap's own restore-position seek.
+  Future<void> _drainSeeks() async {
+    if (_seekInFlight) return;
+    _seekInFlight = true;
+    try {
+      while (true) {
+        final target = _pendingSeekTarget;
+        final player = _player;
+        if (target == null || player == null || _switchingToHq) break;
+        try {
+          await player.seekTo(target);
+        } catch (_) {
+          // A failed native seek is dropped, not retried — the next user
+          // action issues a fresh one.
+        }
+        if (!mounted) break;
+        if (_pendingSeekTarget == target) {
+          _pendingSeekTarget = null;
+          break;
+        }
+        // A newer target arrived while that seek was landing (hold-to-seek
+        // does this every tick) — brief spacing so back-to-back seeks still
+        // can't storm the player.
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+      }
+    } finally {
+      _seekInFlight = false;
+    }
+  }
+
+  /// Begins hold-to-seek in [direction] (+1 forward, -1 back): the target
+  /// advances continuously while the control is held, starting slow and
+  /// ramping linearly (see [holdSeekRateAt]). Targets go through the
+  /// serialized seek pipeline, so frames update as each seek lands without
+  /// ever storming the player.
+  void _startHoldSeek(int direction) {
+    final player = _player;
+    if (player == null) return;
+    _holdSeekTimer?.cancel();
+    _holdSeekBase = _pendingSeekTarget ?? player.position;
+    _holdSeekAccumulated = 0;
+    _holdSeekElapsed = 0;
+    // Pin the controls while the hold is active; _endHoldSeek reschedules.
+    _hideControlsTimer?.cancel();
+    setState(() {
+      _holdSeekDirection = direction;
+      _showControls = true;
+    });
+    const tickSeconds = AppConstants.holdSeekTickMs / 1000.0;
+    _holdSeekTimer = Timer.periodic(
+      const Duration(milliseconds: AppConstants.holdSeekTickMs),
+      (_) {
+        _holdSeekElapsed += tickSeconds;
+        setState(() {
+          _holdSeekAccumulated +=
+              holdSeekRateAt(_holdSeekElapsed) * tickSeconds;
+        });
+        _requestSeek(
+          _holdSeekBase +
+              Duration(
+                milliseconds: (_holdSeekDirection * _holdSeekAccumulated * 1000)
+                    .round(),
+              ),
+        );
+      },
+    );
+  }
+
+  void _endHoldSeek() {
+    if (_holdSeekDirection == 0) return;
+    _holdSeekTimer?.cancel();
+    _holdSeekTimer = null;
+    setState(() => _holdSeekDirection = 0);
     _scheduleHideControls();
+  }
+
+  /// "+37s" / "-1:12" — the accumulated hold-to-seek amount shown in the held
+  /// skip control's label.
+  String _holdSeekLabel() {
+    final seconds = _holdSeekAccumulated.round();
+    final sign = _holdSeekDirection < 0 ? '-' : '+';
+    if (seconds < 60) return '$sign${seconds}s';
+    return '$sign${_formatTimestamp(Duration(seconds: seconds))}';
   }
 
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
@@ -994,6 +1146,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     _adWsSubscription?.cancel();
     _progressTimer?.cancel();
     _hideControlsTimer?.cancel();
+    _holdSeekTimer?.cancel();
     _resumeBannerTimer?.cancel();
     _skipToastTimer?.cancel();
     _previewTimeout?.cancel();
@@ -1163,8 +1316,15 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
                   player: _player!,
                   onBack: _navigateBack,
                   onSeekRelative: _seekRelative,
+                  onSeekAbsolute: _requestSeek,
                   onSeekStart: _onScrubStart,
+                  onScrubUpdate: _onScrubUpdate,
                   onSeekEnd: _onScrubEnd,
+                  scrubPreviewFraction: _scrubPreviewFraction,
+                  holdDirection: _holdSeekDirection,
+                  holdLabel: _holdSeekDirection != 0 ? _holdSeekLabel() : null,
+                  onHoldStart: _startHoldSeek,
+                  onHoldEnd: _endHoldSeek,
                   onPlayPause: _togglePlayPause,
                   onInteraction: _scheduleHideControls,
                   isQueued: isQueued,
@@ -1268,6 +1428,21 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   return (seekToMs: null, inFlightEnd: inFlightEnd);
 }
 
+/// Hold-to-seek rate (video-seconds per held second) after the control has
+/// been held for [heldSeconds]: starts at [AppConstants.holdSeekInitialRate]
+/// and ramps linearly by [AppConstants.holdSeekRampPerSecond] each second,
+/// capped at [AppConstants.holdSeekMaxRate]. Pure, so the ramp is
+/// unit-testable without a live player.
+@visibleForTesting
+double holdSeekRateAt(double heldSeconds) {
+  final rate =
+      AppConstants.holdSeekInitialRate +
+      AppConstants.holdSeekRampPerSecond * heldSeconds;
+  return rate > AppConstants.holdSeekMaxRate
+      ? AppConstants.holdSeekMaxRate
+      : rate;
+}
+
 /// Formats a playback timestamp as M:SS, or H:MM:SS once it crosses an hour.
 String _formatTimestamp(Duration d) {
   final hours = d.inHours;
@@ -1340,10 +1515,29 @@ class _ControlsOverlay extends StatelessWidget {
   final VoidCallback onBack;
   final void Function(int) onSeekRelative;
 
+  /// Commits a seek to an absolute position (scrub release / bar tap). All
+  /// seeks funnel through the screen's serialized pipeline.
+  final void Function(Duration) onSeekAbsolute;
+
   /// Called when the viewer begins / ends dragging the seek bar, so the screen
   /// can suspend sponsor auto-skip during a manual scrub.
   final VoidCallback onSeekStart;
   final VoidCallback onSeekEnd;
+
+  /// Live drag fraction during a scrub, so the timestamp previews the target.
+  final void Function(double) onScrubUpdate;
+
+  /// The 0–1 fraction being previewed while the seek bar is dragged; null
+  /// when idle. Set alongside [onScrubUpdate] by the screen.
+  final double? scrubPreviewFraction;
+
+  /// Hold-to-seek passthroughs: which control is held (+1/-1, 0 idle), the
+  /// accumulated-amount label to show on it, and the start/end callbacks.
+  final int holdDirection;
+  final String? holdLabel;
+  final void Function(int direction) onHoldStart;
+  final VoidCallback onHoldEnd;
+
   final VoidCallback onPlayPause;
   final VoidCallback onInteraction;
 
@@ -1365,8 +1559,15 @@ class _ControlsOverlay extends StatelessWidget {
     required this.player,
     required this.onBack,
     required this.onSeekRelative,
+    required this.onSeekAbsolute,
     required this.onSeekStart,
+    required this.onScrubUpdate,
     required this.onSeekEnd,
+    required this.scrubPreviewFraction,
+    required this.holdDirection,
+    required this.holdLabel,
+    required this.onHoldStart,
+    required this.onHoldEnd,
     required this.onPlayPause,
     required this.onInteraction,
     required this.isFullscreen,
@@ -1451,17 +1652,18 @@ class _ControlsOverlay extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  IconButton(
-                    iconSize: 48,
-                    icon: const Icon(Icons.replay_10, color: Colors.white),
-                    tooltip:
-                        'Skip back ${AppConstants.skipBackwardSeconds} seconds',
-                    onPressed: () {
+                  SkipControl(
+                    forward: false,
+                    seconds: AppConstants.skipBackwardSeconds,
+                    holdLabel: holdDirection == -1 ? holdLabel : null,
+                    onTap: () {
                       onSeekRelative(-AppConstants.skipBackwardSeconds);
                       onInteraction();
                     },
+                    onHoldStart: () => onHoldStart(-1),
+                    onHoldEnd: onHoldEnd,
                   ),
-                  const SizedBox(width: 32),
+                  const SizedBox(width: 24),
                   ListenableBuilder(
                     listenable: player,
                     builder: (_, __) => IconButton(
@@ -1479,16 +1681,17 @@ class _ControlsOverlay extends StatelessWidget {
                       },
                     ),
                   ),
-                  const SizedBox(width: 32),
-                  IconButton(
-                    iconSize: 48,
-                    icon: const Icon(Icons.forward_10, color: Colors.white),
-                    tooltip:
-                        'Skip forward ${AppConstants.skipForwardSeconds} seconds',
-                    onPressed: () {
+                  const SizedBox(width: 24),
+                  SkipControl(
+                    forward: true,
+                    seconds: AppConstants.skipForwardSeconds,
+                    holdLabel: holdDirection == 1 ? holdLabel : null,
+                    onTap: () {
                       onSeekRelative(AppConstants.skipForwardSeconds);
                       onInteraction();
                     },
+                    onHoldStart: () => onHoldStart(1),
+                    onHoldEnd: onHoldEnd,
                   ),
                 ],
               ),
@@ -1505,14 +1708,24 @@ class _ControlsOverlay extends StatelessWidget {
               child: ListenableBuilder(
                 listenable: player,
                 builder: (_, __) {
-                  final position = player.position;
                   final duration = player.duration;
+                  // While scrubbing, the position label previews the drag
+                  // target (highlighted) instead of the still-playing head —
+                  // the seek itself only fires on release.
+                  final preview = scrubPreviewFraction;
+                  final position = preview != null && duration > Duration.zero
+                      ? Duration(
+                          milliseconds: (duration.inMilliseconds * preview)
+                              .round(),
+                        )
+                      : player.position;
                   return Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       NullFeedProgressBar(
                         progress: duration.inMilliseconds > 0
-                            ? position.inMilliseconds / duration.inMilliseconds
+                            ? player.position.inMilliseconds /
+                                  duration.inMilliseconds
                             : 0,
                         height: 4,
                         semanticLabel: 'Video position',
@@ -1525,13 +1738,15 @@ class _ControlsOverlay extends StatelessWidget {
                               '${_formatTimestamp(duration)}';
                         },
                         onSeek: (fraction) {
-                          final target = Duration(
-                            milliseconds: (fraction * duration.inMilliseconds)
-                                .round(),
+                          onSeekAbsolute(
+                            Duration(
+                              milliseconds: (fraction * duration.inMilliseconds)
+                                  .round(),
+                            ),
                           );
-                          player.seekTo(target);
                           onInteraction();
                         },
+                        onSeekPreview: onScrubUpdate,
                         onSeekStart: onSeekStart,
                         onSeekEnd: onSeekEnd,
                       ),
@@ -1541,8 +1756,10 @@ class _ControlsOverlay extends StatelessWidget {
                         children: [
                           Text(
                             _formatTimestamp(position),
-                            style: const TextStyle(
-                              color: Colors.white70,
+                            style: TextStyle(
+                              color: preview != null
+                                  ? NullFeedTheme.primaryColor
+                                  : Colors.white70,
                               fontSize: 12,
                             ),
                           ),

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -1,12 +1,25 @@
 import 'package:flutter/material.dart';
 import '../config/theme.dart';
 
-class NullFeedProgressBar extends StatelessWidget {
+class NullFeedProgressBar extends StatefulWidget {
   final double progress;
   final double height;
   final Color? foregroundColor;
   final Color? backgroundColor;
+
+  /// Called once per interaction — on tap release, or when a drag lets go —
+  /// with the final 0–1 fraction. Never called while the finger is still
+  /// moving: issuing a native seek on every drag tick cancels and restarts the
+  /// player's in-flight seek dozens of times a second, which on a
+  /// still-buffering source wedges it (stutter → freeze → crash). While
+  /// dragging, the bar tracks the finger locally and reports the would-be
+  /// target through [onSeekPreview] instead.
   final void Function(double)? onSeek;
+
+  /// Called with the 0–1 fraction under the finger on every drag update, so
+  /// the caller can preview the target (e.g. a live timestamp) without any
+  /// seek being issued. Only used when [onSeek] is set.
+  final void Function(double)? onSeekPreview;
 
   /// Called when the viewer begins / ends dragging the seek bar. Lets the
   /// player suspend sponsor auto-skip during a manual scrub so a drag through a
@@ -29,6 +42,7 @@ class NullFeedProgressBar extends StatelessWidget {
     this.foregroundColor,
     this.backgroundColor,
     this.onSeek,
+    this.onSeekPreview,
     this.onSeekStart,
     this.onSeekEnd,
     this.semanticLabel,
@@ -36,34 +50,65 @@ class NullFeedProgressBar extends StatelessWidget {
   });
 
   @override
+  State<NullFeedProgressBar> createState() => _NullFeedProgressBarState();
+}
+
+class _NullFeedProgressBarState extends State<NullFeedProgressBar> {
+  /// The fraction under the finger while a drag is in progress; null when
+  /// idle. Drives the bar's fill during the drag so it follows the finger
+  /// rather than the (still-playing) playhead.
+  double? _dragFraction;
+
+  double _fractionAt(Offset localPosition) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || box.size.width <= 0) return 0;
+    return (localPosition.dx / box.size.width).clamp(0.0, 1.0);
+  }
+
+  void _updateDrag(Offset localPosition) {
+    final fraction = _fractionAt(localPosition);
+    setState(() => _dragFraction = fraction);
+    widget.onSeekPreview?.call(fraction);
+  }
+
+  void _endDrag({required bool commit}) {
+    final fraction = _dragFraction;
+    setState(() => _dragFraction = null);
+    if (commit && fraction != null) widget.onSeek?.call(fraction);
+    widget.onSeekEnd?.call();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final shown = (_dragFraction ?? widget.progress).clamp(0.0, 1.0);
     final bar = ClipRRect(
-      borderRadius: BorderRadius.circular(height / 2),
+      borderRadius: BorderRadius.circular(widget.height / 2),
       child: SizedBox(
-        height: height,
+        height: widget.height,
         child: LinearProgressIndicator(
-          value: progress.clamp(0.0, 1.0),
-          backgroundColor: backgroundColor ?? NullFeedTheme.progressBackground,
+          value: shown,
+          backgroundColor:
+              widget.backgroundColor ?? NullFeedTheme.progressBackground,
           valueColor: AlwaysStoppedAnimation<Color>(
-            foregroundColor ?? NullFeedTheme.progressForeground,
+            widget.foregroundColor ?? NullFeedTheme.progressForeground,
           ),
         ),
       ),
     );
 
-    if (onSeek != null) {
-      final seek = onSeek!;
-      final clamped = progress.clamp(0.0, 1.0);
+    if (widget.onSeek != null) {
+      final seek = widget.onSeek!;
+      final clamped = widget.progress.clamp(0.0, 1.0);
       // Let assistive tech step through the track in 5% increments when fine
       // touch isn't an option.
       final up = (clamped + 0.05).clamp(0.0, 1.0);
       final down = (clamped - 0.05).clamp(0.0, 1.0);
       String valueFor(double fraction) =>
-          semanticValueBuilder?.call(fraction) ??
+          widget.semanticValueBuilder?.call(fraction) ??
           '${(fraction * 100).round()}%';
       return Semantics(
         slider: true,
-        label: semanticLabel ?? 'Seek bar',
+        label: widget.semanticLabel ?? 'Seek bar',
         value: valueFor(clamped),
         increasedValue: valueFor(up),
         decreasedValue: valueFor(down),
@@ -71,25 +116,17 @@ class NullFeedProgressBar extends StatelessWidget {
         onDecrease: () => seek(down),
         excludeSemantics: true,
         child: GestureDetector(
-          onTapDown: (details) {
-            final box = context.findRenderObject() as RenderBox?;
-            if (box != null) {
-              final fraction = (details.localPosition.dx / box.size.width)
-                  .clamp(0.0, 1.0);
-              seek(fraction);
-            }
+          // Seek on release (not press) so a press that turns into a drag
+          // never fires a stray seek at the touch-down point.
+          onTapUp: (details) => seek(_fractionAt(details.localPosition)),
+          onHorizontalDragStart: (details) {
+            widget.onSeekStart?.call();
+            _updateDrag(details.localPosition);
           },
-          onHorizontalDragStart: (_) => onSeekStart?.call(),
-          onHorizontalDragUpdate: (details) {
-            final box = context.findRenderObject() as RenderBox?;
-            if (box != null) {
-              final fraction = (details.localPosition.dx / box.size.width)
-                  .clamp(0.0, 1.0);
-              seek(fraction);
-            }
-          },
-          onHorizontalDragEnd: (_) => onSeekEnd?.call(),
-          onHorizontalDragCancel: () => onSeekEnd?.call(),
+          onHorizontalDragUpdate: (details) =>
+              _updateDrag(details.localPosition),
+          onHorizontalDragEnd: (_) => _endDrag(commit: true),
+          onHorizontalDragCancel: () => _endDrag(commit: false),
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),
             child: bar,

--- a/lib/widgets/skip_control.dart
+++ b/lib/widgets/skip_control.dart
@@ -93,6 +93,9 @@ class _SkipControlState extends State<SkipControl>
           'Press and hold to $holdVerb.',
       child: Tooltip(
         message: 'Skip $direction ${widget.seconds}s — hold to $holdVerb',
+        // Never trigger on long-press (the touch default): that would race
+        // the hold-to-seek gesture in the arena. Hover still shows it.
+        triggerMode: TooltipTriggerMode.manual,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: _handleTap,

--- a/lib/widgets/skip_control.dart
+++ b/lib/widgets/skip_control.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import '../config/theme.dart';
+
+/// Skip-back / skip-forward control for the player overlay: a trio of
+/// chevrons over a seconds label, replacing the stock replay_10 / forward_10
+/// icons.
+///
+/// A tap fires [onTap] (one fixed skip) and plays a single brightness sweep
+/// across the chevrons in the skip direction. Press-and-hold fires
+/// [onHoldStart]; while the hold is active the caller passes the accumulated
+/// amount (e.g. "+45s") as [holdLabel], which replaces the seconds label and
+/// keeps the sweep animating on repeat until [onHoldEnd].
+class SkipControl extends StatefulWidget {
+  /// Points the chevrons (and the sweep) right when true, left when false.
+  final bool forward;
+
+  /// The fixed skip size a tap performs, shown as the idle label ("10s").
+  final int seconds;
+
+  /// Accumulated hold-to-seek amount while a hold is active; null when idle.
+  final String? holdLabel;
+
+  final VoidCallback onTap;
+  final VoidCallback onHoldStart;
+  final VoidCallback onHoldEnd;
+
+  const SkipControl({
+    super.key,
+    required this.forward,
+    required this.seconds,
+    required this.onTap,
+    required this.onHoldStart,
+    required this.onHoldEnd,
+    this.holdLabel,
+  });
+
+  @override
+  State<SkipControl> createState() => _SkipControlState();
+}
+
+class _SkipControlState extends State<SkipControl>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _sweep = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 550),
+  );
+
+  bool get _holding => widget.holdLabel != null;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_holding) _sweep.repeat();
+    // After a one-shot tap sweep, snap back to the idle (uniform) look.
+    _sweep.addStatusListener((status) {
+      if (status == AnimationStatus.completed && !_holding) {
+        _sweep.value = 0;
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(SkipControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final wasHolding = oldWidget.holdLabel != null;
+    if (_holding && !wasHolding) {
+      _sweep.repeat();
+    } else if (!_holding && wasHolding) {
+      _sweep.stop();
+      _sweep.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _sweep.dispose();
+    super.dispose();
+  }
+
+  void _handleTap() {
+    _sweep.forward(from: 0);
+    widget.onTap();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = widget.forward ? 'forward' : 'back';
+    final holdVerb = widget.forward ? 'fast-forward' : 'rewind';
+    return Semantics(
+      button: true,
+      label:
+          'Skip $direction ${widget.seconds} seconds. '
+          'Press and hold to $holdVerb.',
+      child: Tooltip(
+        message: 'Skip $direction ${widget.seconds}s — hold to $holdVerb',
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _handleTap,
+          onLongPressStart: (_) => widget.onHoldStart(),
+          onLongPressEnd: (_) => widget.onHoldEnd(),
+          onLongPressCancel: widget.onHoldEnd,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            decoration: BoxDecoration(
+              color: _holding ? Colors.white12 : Colors.transparent,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            // The chevrons + label are decorative; the outer Semantics node
+            // carries the full description, so keep the raw "10s" text from
+            // being appended to it.
+            child: ExcludeSemantics(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  AnimatedBuilder(
+                    animation: _sweep,
+                    builder: (_, __) => CustomPaint(
+                      size: const Size(52, 22),
+                      painter: _ChevronSweepPainter(
+                        wave: _sweep.isAnimating ? _sweep.value : null,
+                        forward: widget.forward,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    widget.holdLabel ?? '${widget.seconds}s',
+                    style: TextStyle(
+                      color: _holding
+                          ? NullFeedTheme.primaryColor
+                          : Colors.white,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Three stroked chevrons with a brightness peak that sweeps across them in
+/// the skip direction. [wave] is the 0–1 sweep position; null renders the
+/// idle state (all chevrons at uniform brightness).
+class _ChevronSweepPainter extends CustomPainter {
+  final double? wave;
+  final bool forward;
+  final Color color;
+
+  const _ChevronSweepPainter({
+    required this.wave,
+    required this.forward,
+    required this.color,
+  });
+
+  static const int _count = 3;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    final armWidth = size.width * 0.2;
+    final step = (size.width - armWidth) / _count;
+    final top = size.height * 0.08;
+    final bottom = size.height * 0.92;
+    final mid = size.height / 2;
+
+    for (var i = 0; i < _count; i++) {
+      final x = i * step + step / 2;
+      final tip = forward ? x + armWidth : x;
+      final base = forward ? x : x + armWidth;
+
+      double opacity;
+      final w = wave;
+      if (w == null) {
+        opacity = 0.9;
+      } else {
+        // The peak enters before the first chevron and exits past the last,
+        // travelling in the skip direction.
+        final order = forward ? i : _count - 1 - i;
+        final peak = w * (_count + 1) - 1;
+        final glow = (1 - (peak - order).abs()).clamp(0.0, 1.0);
+        opacity = 0.30 + 0.70 * glow;
+      }
+      paint.color = color.withValues(alpha: opacity);
+
+      final path = Path()
+        ..moveTo(base, top)
+        ..lineTo(tip, mid)
+        ..lineTo(base, bottom);
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_ChevronSweepPainter oldDelegate) =>
+      wave != oldDelegate.wave ||
+      forward != oldDelegate.forward ||
+      color != oldDelegate.color;
+}

--- a/test/unit/hold_seek_test.dart
+++ b/test/unit/hold_seek_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/config/constants.dart';
+import 'package:nullfeed/screens/video_player_screen.dart';
+
+void main() {
+  group('holdSeekRateAt', () {
+    test('starts at the initial rate', () {
+      expect(holdSeekRateAt(0), AppConstants.holdSeekInitialRate);
+    });
+
+    test('ramps linearly with hold time', () {
+      expect(
+        holdSeekRateAt(1),
+        AppConstants.holdSeekInitialRate + AppConstants.holdSeekRampPerSecond,
+      );
+      expect(
+        holdSeekRateAt(3),
+        AppConstants.holdSeekInitialRate +
+            3 * AppConstants.holdSeekRampPerSecond,
+      );
+    });
+
+    test('caps at the max rate', () {
+      expect(holdSeekRateAt(600), AppConstants.holdSeekMaxRate);
+      // The cap is a ceiling, not a cliff: just before the cap the ramp is
+      // still linear.
+      const capAt =
+          (AppConstants.holdSeekMaxRate - AppConstants.holdSeekInitialRate) /
+          AppConstants.holdSeekRampPerSecond;
+      expect(holdSeekRateAt(capAt), AppConstants.holdSeekMaxRate);
+      expect(
+        holdSeekRateAt(capAt - 0.5),
+        lessThan(AppConstants.holdSeekMaxRate),
+      );
+    });
+
+    test('never decreases as the hold gets longer', () {
+      var previous = holdSeekRateAt(0);
+      for (var t = 0.5; t <= 20; t += 0.5) {
+        final rate = holdSeekRateAt(t);
+        expect(rate, greaterThanOrEqualTo(previous));
+        previous = rate;
+      }
+    });
+  });
+}

--- a/test/widgets/progress_bar_test.dart
+++ b/test/widgets/progress_bar_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/widgets/progress_bar.dart';
+
+/// Regression tests for the seek-on-release behavior: issuing a native seek
+/// on every drag tick storms the player's seek pipeline and wedges it, so a
+/// drag must produce exactly one onSeek — on release — with previews flowing
+/// through onSeekPreview instead.
+void main() {
+  const barWidth = 200.0;
+
+  Future<void> pumpBar(
+    WidgetTester tester, {
+    required List<double> seeks,
+    List<double>? previews,
+    void Function()? onStart,
+    void Function()? onEnd,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: barWidth,
+              child: NullFeedProgressBar(
+                progress: 0.25,
+                onSeek: seeks.add,
+                onSeekPreview: previews?.add,
+                onSeekStart: onStart,
+                onSeekEnd: onEnd,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('drag previews continuously but seeks once, on release', (
+    tester,
+  ) async {
+    final seeks = <double>[];
+    final previews = <double>[];
+    var started = 0;
+    var ended = 0;
+    await pumpBar(
+      tester,
+      seeks: seeks,
+      previews: previews,
+      onStart: () => started++,
+      onEnd: () => ended++,
+    );
+
+    final barFinder = find.byType(NullFeedProgressBar);
+    final topLeft = tester.getTopLeft(barFinder);
+    final center = tester.getCenter(barFinder);
+
+    final gesture = await tester.startGesture(
+      Offset(topLeft.dx + barWidth * 0.2, center.dy),
+    );
+    await tester.pump();
+    // Move well past the drag slop, in several ticks.
+    for (var i = 0; i < 5; i++) {
+      await gesture.moveBy(const Offset(24, 0));
+      await tester.pump();
+    }
+    expect(seeks, isEmpty, reason: 'no seek may fire while still dragging');
+    expect(started, 1);
+    expect(previews, isNotEmpty);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(seeks, hasLength(1), reason: 'exactly one seek, on release');
+    expect(ended, 1);
+    // Released at ~0.2 + 120/200 of the width.
+    expect(seeks.single, closeTo(0.8, 0.1));
+    // The final preview matches where the seek landed.
+    expect(previews.last, closeTo(seeks.single, 0.01));
+  });
+
+  testWidgets('tap seeks once to the tapped fraction', (tester) async {
+    final seeks = <double>[];
+    await pumpBar(tester, seeks: seeks);
+
+    final barFinder = find.byType(NullFeedProgressBar);
+    final topLeft = tester.getTopLeft(barFinder);
+    final center = tester.getCenter(barFinder);
+
+    await tester.tapAt(Offset(topLeft.dx + barWidth * 0.75, center.dy));
+    await tester.pump();
+
+    expect(seeks, hasLength(1));
+    expect(seeks.single, closeTo(0.75, 0.05));
+  });
+
+  testWidgets('system-cancelled drag ends the scrub with a single commit', (
+    tester,
+  ) async {
+    // Once a horizontal drag is accepted, Flutter routes a pointer cancel to
+    // drag END (drag-cancel only fires pre-acceptance), so an interrupted
+    // scrub behaves like a release: the scrub ends and exactly one seek — to
+    // the last previewed spot — is committed. Never a storm, never a leaked
+    // scrub state.
+    final seeks = <double>[];
+    var started = 0;
+    var ended = 0;
+    await pumpBar(
+      tester,
+      seeks: seeks,
+      onStart: () => started++,
+      onEnd: () => ended++,
+    );
+
+    final barFinder = find.byType(NullFeedProgressBar);
+    final topLeft = tester.getTopLeft(barFinder);
+    final center = tester.getCenter(barFinder);
+
+    final gesture = await tester.startGesture(
+      Offset(topLeft.dx + barWidth * 0.2, center.dy),
+    );
+    await tester.pump();
+    await gesture.moveBy(const Offset(40, 0));
+    await tester.pump();
+    await gesture.cancel();
+    await tester.pump();
+
+    expect(started, 1);
+    expect(ended, 1);
+    expect(seeks, hasLength(1));
+    expect(seeks.single, closeTo(0.4, 0.05));
+  });
+}

--- a/test/widgets/skip_control_test.dart
+++ b/test/widgets/skip_control_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/config/theme.dart';
+import 'package:nullfeed/widgets/skip_control.dart';
+
+void main() {
+  Future<void> pumpControl(
+    WidgetTester tester, {
+    bool forward = true,
+    String? holdLabel,
+    VoidCallback? onTap,
+    VoidCallback? onHoldStart,
+    VoidCallback? onHoldEnd,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: NullFeedTheme.darkTheme,
+        home: Scaffold(
+          body: Center(
+            child: SkipControl(
+              forward: forward,
+              seconds: 10,
+              holdLabel: holdLabel,
+              onTap: onTap ?? () {},
+              onHoldStart: onHoldStart ?? () {},
+              onHoldEnd: onHoldEnd ?? () {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('tap fires onTap once', (tester) async {
+    var taps = 0;
+    await pumpControl(tester, onTap: () => taps++);
+
+    await tester.tap(find.byType(SkipControl));
+    // Let the one-shot sweep animation run out.
+    await tester.pumpAndSettle();
+
+    expect(taps, 1);
+  });
+
+  testWidgets('press-and-hold fires onHoldStart, release fires onHoldEnd', (
+    tester,
+  ) async {
+    var starts = 0;
+    var ends = 0;
+    await pumpControl(
+      tester,
+      onHoldStart: () => starts++,
+      onHoldEnd: () => ends++,
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(SkipControl)),
+    );
+    // Past the long-press threshold.
+    await tester.pump(const Duration(milliseconds: 700));
+    expect(starts, 1);
+    expect(ends, 0);
+
+    await gesture.up();
+    await tester.pump();
+    expect(ends, 1);
+  });
+
+  testWidgets('idle label shows the skip size; holdLabel replaces it', (
+    tester,
+  ) async {
+    await pumpControl(tester);
+    expect(find.text('10s'), findsOneWidget);
+
+    await pumpControl(tester, holdLabel: '+45s');
+    expect(find.text('+45s'), findsOneWidget);
+    expect(find.text('10s'), findsNothing);
+
+    // Back to idle (hold released) — the repeating sweep must stop so the
+    // test's ticker assertions (and the widget) settle.
+    await pumpControl(tester);
+    expect(find.text('10s'), findsOneWidget);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('exposes a button with a hold hint to assistive tech', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    await pumpControl(tester);
+
+    expect(
+      find.bySemanticsLabel(
+        'Skip forward 10 seconds. Press and hold to fast-forward.',
+      ),
+      findsOneWidget,
+    );
+
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Why

Seeking through a video could freeze/lock up the player. Root cause: manual seeks storm the native seek pipeline —

- the seek bar issued a `seekTo` on **every drag tick** while scrubbing,
- rapid ±10s taps each re-sought from a stale `position`,

and each new native seek cancels/restarts the in-flight one; on a still-buffering source that livelocks the player (stutter → freeze → crash). This is the exact failure mode the sponsor-skip guard already documents — the manual seek paths just never got the same protection.

## What

**Seek serialization (the fix)**
- All seeks — taps, double-taps, keyboard arrows, scrub release, restart-from-start, and sponsor auto-skip — funnel through `_requestSeek` → `_drainSeeks`: exactly one native seek in flight, newer targets coalesce into a pending target, 80ms spacing between chained seeks. The drain pauses during the preview→HQ swap and resumes after, so a manual seek can't fight the swap's restore-position seek.
- The scrub bar previews locally while dragging (bar follows the finger, timestamp shows the highlighted target) and commits **one** seek on release.
- Relative skips accumulate from the pending target: three quick forward taps = +30s, not three re-seeks to the same spot.
- Sponsor auto-skip stands down while any manual seek is pending/landing.

**New skip controls (UI)**
- `replay_10`/`forward_10` icons replaced with a `SkipControl` widget: triple chevrons over a seconds label, with a brightness sweep in the skip direction on tap.
- **Press-and-hold seeks continuously**: starts at 8 s/s and ramps linearly (+12 s/s per second) to a 120 s/s cap. The control shows the live accumulated amount ("+45s", "-1:12") while held, chevrons sweep on repeat, and frames update as each serialized seek lands. Works on both forward and backward.
- Full a11y: button semantics with a hold hint, decorative text excluded.

## Verification

- `dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` clean, `flutter test` 195/195.
- New tests: hold-ramp math (initial/linear/cap/monotonic), progress-bar drag previews-but-seeks-once-on-release + tap + system-cancel commit, SkipControl tap/hold gestures + labels + semantics.

Also audited the other seek-freeze suspects: tvOS uses AVKit's native transport (no storm risk), and all three backend stream endpoints honor Range/206, so the client-side storm was the remaining cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)