### PR TITLE
Fix iOS seeks restarting the video at 0 (zero-duration clamp in better_player)

### DIFF
--- a/lib/services/playback/nf_playback_io_impl.dart
+++ b/lib/services/playback/nf_playback_io_impl.dart
@@ -7,6 +7,10 @@ import 'package:better_player_plus/better_player_plus.dart';
 // stable.
 // ignore: implementation_imports
 import 'package:better_player_plus/src/enum/aspect_enum.dart';
+// The platform interface isn't re-exported either; needed for the
+// zero-duration seek fallback in [seekTo]. Same version-pin rationale.
+// ignore: implementation_imports
+import 'package:better_player_plus/src/video_player/video_player_platform_interface.dart';
 import 'package:flutter/widgets.dart';
 
 import 'nf_playback_controller.dart';
@@ -160,7 +164,26 @@ class BetterPlayerNfController extends NfPlaybackController {
   Future<void> pause() => _controller.pause();
 
   @override
-  Future<void> seekTo(Duration position) => _controller.seekTo(position);
+  Future<void> seekTo(Duration position) async {
+    final vpc = _controller.videoPlayerController;
+    if (vpc == null) return;
+    // better_player's Dart layer clamps every seek to `value.duration` — and
+    // some streams misreport their duration as zero/unknown at initialization
+    // (see the `finished` note in [_onEvent]). Through that clamp, EVERY seek
+    // on such a stream becomes a seek to 0: the video "restarts from the
+    // top" on any skip or scrub. When duration is unusable, seek the platform
+    // directly instead — AVPlayer knows the real duration and clamps sanely.
+    final duration = vpc.value.duration;
+    if (duration == null || duration <= Duration.zero) {
+      final clamped = position < Duration.zero ? Duration.zero : position;
+      // textureId is marked visibleForTesting upstream, but it is the only
+      // handle the platform channel accepts; the dependency is version-pinned.
+      // ignore: invalid_use_of_visible_for_testing_member
+      await VideoPlayerPlatform.instance.seekTo(vpc.textureId, clamped);
+      return;
+    }
+    return _controller.seekTo(position);
+  }
 
   @override
   Future<void> setSpeed(double speed) => _controller.setSpeed(speed);


### PR DESCRIPTION
## Why

On iOS, pressing a skip control or dragging the seek bar could send the video **back to 0 and restart it**. Root cause is in better_player's vendored `video_player.seekTo`:

```dart
if (position! > value.duration!) {
  positionToSeek = value.duration;   // duration == 0 → every seek lands at 0
}
```

Some of our streams misreport their duration as zero/unknown at initialization (already documented in `nf_playback_io_impl.dart`'s `finished`-event note). Through that clamp, **every** seek on such a stream becomes a seek to zero. Web is unaffected — the official `video_player` there reads the real duration off the `<video>` element — confirmed by driving the web app live against a real server: single press → single seek → exact +10s, on both HQ and preview streams.

## What

In `BetterPlayerNfController.seekTo`: when the reported duration is null or ≤ 0, bypass the Dart-side clamp and seek the platform channel directly (low-clamped at 0). AVPlayer knows the stream's real duration natively and clamps sanely. Streams with a healthy reported duration keep the normal path (with its `_seekPosition` bookkeeping).

Skipping better_player's Dart path on the fallback also skips its synthesized parameter-less `finished` event — which is the event our `_onEvent` already has to guard against, so nothing of value is lost.

## Verification

- `dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` clean, `flutter test` 195/195.
- Web verified live (unaffected path, correct behavior). iOS on-device verification to follow post-merge per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)