### PR TITLE
Fix playback progress fill and seek target

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -73,8 +73,8 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
   /// playhead lands past the segment. See [sponsorSkipDecision].
   double? _skipSeekInFlightEnd;
 
-  /// True while the viewer is actively dragging the seek bar. Suspends sponsor
-  /// auto-skip so a manual scrub through a sponsor segment isn't fought by an
+  /// True while the viewer has a pointer down on the seek bar. Suspends sponsor
+  /// auto-skip so a tap or scrub through a sponsor segment isn't fought by an
   /// auto-seek — competing seeks on a still-buffering source wedge the player.
   bool _isScrubbing = false;
 
@@ -906,9 +906,15 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     });
   }
 
-  /// The viewer grabbed the seek bar — suspend sponsor auto-skip until they
-  /// let go so a manual scrub through a sponsor isn't fought by an auto-seek.
-  void _onScrubStart() => _isScrubbing = true;
+  /// The viewer touched the seek bar — pin the controls immediately and suspend
+  /// sponsor auto-skip until release. Waiting for drag recognition here leaves
+  /// a slow touch vulnerable to the normal controls auto-hide timer.
+  void _onScrubStart() {
+    _isScrubbing = true;
+    // Keep the controls pinned for the whole gesture. A careful scrub can
+    // easily outlast the normal three-second auto-hide timeout.
+    _hideControlsTimer?.cancel();
+  }
 
   /// Live drag position from the seek bar; no seek is issued — this only
   /// drives the previewed timestamp in the overlay until release.
@@ -925,6 +931,7 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     if (_scrubPreviewFraction != null) {
       setState(() => _scrubPreviewFraction = null);
     }
+    _scheduleHideControls();
   }
 
   /// When the video plays through to the end, advance into the queue: consume
@@ -1001,7 +1008,10 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
     // the same), which would auto-advance to the next queued video instead of
     // just nudging the playhead — so a skip-forward near the end must stay a
     // moment short of the end. Natural end-of-playback still advances.
-    final duration = player.duration;
+    final duration = effectivePlaybackDuration(
+      player.duration,
+      Duration(seconds: _video?.durationSeconds ?? 0),
+    );
     if (duration > Duration.zero) {
       final maxTarget = duration - const Duration(seconds: 1);
       if (clamped > maxTarget) clamped = maxTarget;
@@ -1314,6 +1324,9 @@ class _VideoPlayerScreenState extends ConsumerState<VideoPlayerScreen> {
               if (_showControls && _isInitialized)
                 _ControlsOverlay(
                   player: _player!,
+                  fallbackDuration: Duration(
+                    seconds: video?.durationSeconds ?? 0,
+                  ),
                   onBack: _navigateBack,
                   onSeekRelative: _seekRelative,
                   onSeekAbsolute: _requestSeek,
@@ -1443,6 +1456,27 @@ double holdSeekRateAt(double heldSeconds) {
       : rate;
 }
 
+/// Duration used by the seek timeline. Native media duration is authoritative
+/// when available; progressive iOS sources can temporarily report zero even
+/// while position advances, so backend metadata is the fallback for that case.
+@visibleForTesting
+Duration effectivePlaybackDuration(
+  Duration nativeDuration,
+  Duration metadataDuration,
+) {
+  if (nativeDuration > Duration.zero) return nativeDuration;
+  if (metadataDuration > Duration.zero) return metadataDuration;
+  return Duration.zero;
+}
+
+/// Converts a playhead position into the clamped fill fraction shown by the
+/// seek timeline.
+@visibleForTesting
+double playbackProgressFraction(Duration position, Duration duration) {
+  if (duration <= Duration.zero) return 0;
+  return (position.inMilliseconds / duration.inMilliseconds).clamp(0.0, 1.0);
+}
+
 /// Formats a playback timestamp as M:SS, or H:MM:SS once it crosses an hour.
 String _formatTimestamp(Duration d) {
   final hours = d.inHours;
@@ -1512,6 +1546,7 @@ class _ResumeBanner extends StatelessWidget {
 
 class _ControlsOverlay extends StatelessWidget {
   final NfPlaybackController player;
+  final Duration fallbackDuration;
   final VoidCallback onBack;
   final void Function(int) onSeekRelative;
 
@@ -1557,6 +1592,7 @@ class _ControlsOverlay extends StatelessWidget {
 
   const _ControlsOverlay({
     required this.player,
+    required this.fallbackDuration,
     required this.onBack,
     required this.onSeekRelative,
     required this.onSeekAbsolute,
@@ -1708,7 +1744,10 @@ class _ControlsOverlay extends StatelessWidget {
               child: ListenableBuilder(
                 listenable: player,
                 builder: (_, __) {
-                  final duration = player.duration;
+                  final duration = effectivePlaybackDuration(
+                    player.duration,
+                    fallbackDuration,
+                  );
                   // While scrubbing, the position label previews the drag
                   // target (highlighted) instead of the still-playing head —
                   // the seek itself only fires on release.
@@ -1723,10 +1762,10 @@ class _ControlsOverlay extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       NullFeedProgressBar(
-                        progress: duration.inMilliseconds > 0
-                            ? player.position.inMilliseconds /
-                                  duration.inMilliseconds
-                            : 0,
+                        progress: playbackProgressFraction(
+                          player.position,
+                          duration,
+                        ),
                         height: 4,
                         semanticLabel: 'Video position',
                         semanticValueBuilder: (fraction) {

--- a/lib/widgets/progress_bar.dart
+++ b/lib/widgets/progress_bar.dart
@@ -1,7 +1,15 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import '../config/theme.dart';
 
 class NullFeedProgressBar extends StatefulWidget {
+  /// Interactive seek bars keep a full touch-sized hit target while the
+  /// painted track remains visually compact. Passive card bars still use
+  /// [height] as their total height.
+  static const double interactiveHeight = 48;
+
+  static const double _thumbDiameter = 16;
+
   final double progress;
   final double height;
   final Color? foregroundColor;
@@ -21,9 +29,10 @@ class NullFeedProgressBar extends StatefulWidget {
   /// seek being issued. Only used when [onSeek] is set.
   final void Function(double)? onSeekPreview;
 
-  /// Called when the viewer begins / ends dragging the seek bar. Lets the
-  /// player suspend sponsor auto-skip during a manual scrub so a drag through a
-  /// sponsor segment isn't fought by an auto-seek. Only used when [onSeek] is set.
+  /// Called as soon as the viewer puts a pointer down on the seek bar, and when
+  /// that pointer is released or cancelled. Lets the player pin its controls
+  /// and suspend sponsor auto-skip before Flutter has recognized a tap or drag.
+  /// Only used when [onSeek] is set.
   final VoidCallback? onSeekStart;
   final VoidCallback? onSeekEnd;
 
@@ -75,7 +84,6 @@ class _NullFeedProgressBarState extends State<NullFeedProgressBar> {
     final fraction = _dragFraction;
     setState(() => _dragFraction = null);
     if (commit && fraction != null) widget.onSeek?.call(fraction);
-    widget.onSeekEnd?.call();
   }
 
   @override
@@ -115,21 +123,78 @@ class _NullFeedProgressBarState extends State<NullFeedProgressBar> {
         onIncrease: () => seek(up),
         onDecrease: () => seek(down),
         excludeSemantics: true,
-        child: GestureDetector(
-          // Seek on release (not press) so a press that turns into a drag
-          // never fires a stray seek at the touch-down point.
-          onTapUp: (details) => seek(_fractionAt(details.localPosition)),
-          onHorizontalDragStart: (details) {
-            widget.onSeekStart?.call();
-            _updateDrag(details.localPosition);
-          },
-          onHorizontalDragUpdate: (details) =>
-              _updateDrag(details.localPosition),
-          onHorizontalDragEnd: (_) => _endDrag(commit: true),
-          onHorizontalDragCancel: () => _endDrag(commit: false),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: bar,
+        child: Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: (_) => widget.onSeekStart?.call(),
+          onPointerUp: (_) => widget.onSeekEnd?.call(),
+          onPointerCancel: (_) => widget.onSeekEnd?.call(),
+          child: GestureDetector(
+            // The painted track is intentionally slim. Make the full 48dp
+            // wrapper participate in hit testing so users do not have to land
+            // exactly on a 4dp line to start a scrub.
+            behavior: HitTestBehavior.opaque,
+            dragStartBehavior: DragStartBehavior.down,
+            // Seek on release (not press) so a press that turns into a drag
+            // never fires a stray seek at the touch-down point.
+            onTapUp: (details) => seek(_fractionAt(details.localPosition)),
+            onHorizontalDragStart: (details) =>
+                _updateDrag(details.localPosition),
+            onHorizontalDragUpdate: (details) =>
+                _updateDrag(details.localPosition),
+            onHorizontalDragEnd: (_) => _endDrag(commit: true),
+            onHorizontalDragCancel: () => _endDrag(commit: false),
+            child: SizedBox(
+              height: NullFeedProgressBar.interactiveHeight,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final maxThumbLeft =
+                      constraints.maxWidth - NullFeedProgressBar._thumbDiameter;
+                  final thumbLeft =
+                      (shown * constraints.maxWidth -
+                              NullFeedProgressBar._thumbDiameter / 2)
+                          .clamp(0.0, maxThumbLeft < 0 ? 0.0 : maxThumbLeft);
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Positioned(
+                        left: 0,
+                        right: 0,
+                        top:
+                            (NullFeedProgressBar.interactiveHeight -
+                                widget.height) /
+                            2,
+                        child: bar,
+                      ),
+                      Positioned(
+                        left: thumbLeft,
+                        top:
+                            (NullFeedProgressBar.interactiveHeight -
+                                NullFeedProgressBar._thumbDiameter) /
+                            2,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color:
+                                widget.foregroundColor ??
+                                NullFeedTheme.progressForeground,
+                            shape: BoxShape.circle,
+                            border: Border.all(color: Colors.white, width: 2),
+                            boxShadow: const [
+                              BoxShadow(
+                                color: Color(0x66000000),
+                                blurRadius: 4,
+                              ),
+                            ],
+                          ),
+                          child: const SizedBox.square(
+                            dimension: NullFeedProgressBar._thumbDiameter,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
           ),
         ),
       );

--- a/test/unit/playback_timeline_test.dart
+++ b/test/unit/playback_timeline_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nullfeed/screens/video_player_screen.dart';
+
+void main() {
+  group('playback timeline duration', () {
+    test('uses metadata when the native stream duration is unknown', () {
+      final duration = effectivePlaybackDuration(
+        Duration.zero,
+        const Duration(minutes: 10),
+      );
+
+      expect(duration, const Duration(minutes: 10));
+      expect(
+        playbackProgressFraction(
+          const Duration(minutes: 2, seconds: 30),
+          duration,
+        ),
+        0.25,
+      );
+    });
+
+    test('prefers a valid native duration over stale metadata', () {
+      final duration = effectivePlaybackDuration(
+        const Duration(minutes: 8),
+        const Duration(minutes: 10),
+      );
+
+      expect(duration, const Duration(minutes: 8));
+    });
+
+    test('unknown duration produces an empty fill', () {
+      expect(
+        effectivePlaybackDuration(Duration.zero, Duration.zero),
+        Duration.zero,
+      );
+      expect(
+        playbackProgressFraction(const Duration(seconds: 30), Duration.zero),
+        0,
+      );
+    });
+  });
+}

--- a/test/widgets/progress_bar_test.dart
+++ b/test/widgets/progress_bar_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nullfeed/widgets/progress_bar.dart';
 
@@ -15,6 +16,7 @@ void main() {
     List<double>? previews,
     void Function()? onStart,
     void Function()? onEnd,
+    double progress = 0.25,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -23,7 +25,7 @@ void main() {
             child: SizedBox(
               width: barWidth,
               child: NullFeedProgressBar(
-                progress: 0.25,
+                progress: progress,
                 onSeek: seeks.add,
                 onSeekPreview: previews?.add,
                 onSeekStart: onStart,
@@ -35,6 +37,23 @@ void main() {
       ),
     );
   }
+
+  testWidgets('fill reflects progress updates', (tester) async {
+    final seeks = <double>[];
+    await pumpBar(tester, seeks: seeks, progress: 0.25);
+
+    LinearProgressIndicator indicator() => tester.widget(
+      find.descendant(
+        of: find.byType(NullFeedProgressBar),
+        matching: find.byType(LinearProgressIndicator),
+      ),
+    );
+
+    expect(indicator().value, 0.25);
+
+    await pumpBar(tester, seeks: seeks, progress: 0.7);
+    expect(indicator().value, 0.7);
+  });
 
   testWidgets('drag previews continuously but seeks once, on release', (
     tester,
@@ -81,7 +100,14 @@ void main() {
 
   testWidgets('tap seeks once to the tapped fraction', (tester) async {
     final seeks = <double>[];
-    await pumpBar(tester, seeks: seeks);
+    var started = 0;
+    var ended = 0;
+    await pumpBar(
+      tester,
+      seeks: seeks,
+      onStart: () => started++,
+      onEnd: () => ended++,
+    );
 
     final barFinder = find.byType(NullFeedProgressBar);
     final topLeft = tester.getTopLeft(barFinder);
@@ -92,6 +118,94 @@ void main() {
 
     expect(seeks, hasLength(1));
     expect(seeks.single, closeTo(0.75, 0.05));
+    expect(started, 1);
+    expect(ended, 1);
+  });
+
+  testWidgets('seek interaction starts on pointer down before recognition', (
+    tester,
+  ) async {
+    final seeks = <double>[];
+    var started = 0;
+    var ended = 0;
+    await pumpBar(
+      tester,
+      seeks: seeks,
+      onStart: () => started++,
+      onEnd: () => ended++,
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(NullFeedProgressBar)),
+    );
+    expect(started, 1);
+    expect(ended, 0);
+
+    // A slow press stays active until the actual pointer release.
+    await tester.pump(const Duration(seconds: 4));
+    expect(started, 1);
+    expect(ended, 0);
+
+    await gesture.up();
+    await tester.pump();
+    expect(ended, 1);
+  });
+
+  testWidgets('full touch-sized height can start taps and drags', (
+    tester,
+  ) async {
+    final seeks = <double>[];
+    await pumpBar(tester, seeks: seeks);
+
+    final barFinder = find.byType(NullFeedProgressBar);
+    final rect = tester.getRect(barFinder);
+    expect(rect.height, greaterThanOrEqualTo(44));
+
+    // Both points are well outside the painted 4dp track.
+    await tester.tapAt(Offset(rect.left + barWidth * 0.6, rect.top + 2));
+    await tester.pump();
+    expect(seeks.single, closeTo(0.6, 0.05));
+
+    seeks.clear();
+    final gesture = await tester.startGesture(
+      Offset(rect.left + barWidth * 0.2, rect.bottom - 2),
+      kind: PointerDeviceKind.touch,
+    );
+    await gesture.moveBy(const Offset(80, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(seeks.single, closeTo(0.6, 0.08));
+  });
+
+  testWidgets('mouse can drag from outside the painted track', (tester) async {
+    final seeks = <double>[];
+    await pumpBar(tester, seeks: seeks);
+
+    final rect = tester.getRect(find.byType(NullFeedProgressBar));
+    final gesture = await tester.startGesture(
+      Offset(rect.left + barWidth * 0.25, rect.top + 2),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(100, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(seeks.single, closeTo(0.75, 0.08));
+  });
+
+  testWidgets('passive bar keeps its configured compact height', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: NullFeedProgressBar(progress: 0.5, height: 4)),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(NullFeedProgressBar)).height, 4);
   });
 
   testWidgets('system-cancelled drag ends the scrub with a single commit', (


### PR DESCRIPTION
## Summary
- fall back to backend video metadata when the native player reports an unknown duration, keeping fill, timestamps, semantics, seeking, and end clamping consistent
- expand the interactive seek target to 48dp, add a visible thumb, and pin controls from pointer-down through release
- add regression coverage for duration fallback, fill updates, slow holds, and edge-of-target touch and mouse drags

## Verification
- `dart format --set-exit-if-changed .`
- `flutter analyze --fatal-infos --fatal-warnings`
- `flutter test` (203 tests)
- `flutter build web --release`
- Local `flutter build ios --release --no-codesign` was blocked before compilation because Xcode marks its listed iOS 26.5 platform as unavailable; CI remains the iOS build authority.