### PR TITLE
Hide idle skip duration labels

### DIFF
--- a/lib/widgets/skip_control.dart
+++ b/lib/widgets/skip_control.dart
@@ -2,19 +2,19 @@ import 'package:flutter/material.dart';
 import '../config/theme.dart';
 
 /// Skip-back / skip-forward control for the player overlay: a trio of
-/// chevrons over a seconds label, replacing the stock replay_10 / forward_10
-/// icons.
+/// chevrons, replacing the stock replay_10 / forward_10 icons.
 ///
 /// A tap fires [onTap] (one fixed skip) and plays a single brightness sweep
 /// across the chevrons in the skip direction. Press-and-hold fires
 /// [onHoldStart]; while the hold is active the caller passes the accumulated
-/// amount (e.g. "+45s") as [holdLabel], which replaces the seconds label and
-/// keeps the sweep animating on repeat until [onHoldEnd].
+/// amount (e.g. "+45s") as [holdLabel], which appears while seeking and keeps
+/// the sweep animating on repeat until [onHoldEnd].
 class SkipControl extends StatefulWidget {
   /// Points the chevrons (and the sweep) right when true, left when false.
   final bool forward;
 
-  /// The fixed skip size a tap performs, shown as the idle label ("10s").
+  /// The fixed skip size a tap performs, used in the accessibility label and
+  /// tooltip while the visual control remains chevrons-only at rest.
   final int seconds;
 
   /// Accumulated hold-to-seek amount while a hold is active; null when idle.
@@ -109,9 +109,8 @@ class _SkipControlState extends State<SkipControl>
               color: _holding ? Colors.white12 : Colors.transparent,
               borderRadius: BorderRadius.circular(16),
             ),
-            // The chevrons + label are decorative; the outer Semantics node
-            // carries the full description, so keep the raw "10s" text from
-            // being appended to it.
+            // The chevrons and optional hold label are decorative; the outer
+            // Semantics node carries the full control description.
             child: ExcludeSemantics(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -127,18 +126,18 @@ class _SkipControlState extends State<SkipControl>
                       ),
                     ),
                   ),
-                  const SizedBox(height: 4),
-                  Text(
-                    widget.holdLabel ?? '${widget.seconds}s',
-                    style: TextStyle(
-                      color: _holding
-                          ? NullFeedTheme.primaryColor
-                          : Colors.white,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                      fontFeatures: const [FontFeature.tabularFigures()],
+                  if (widget.holdLabel case final holdLabel?) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      holdLabel,
+                      style: const TextStyle(
+                        color: NullFeedTheme.primaryColor,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        fontFeatures: [FontFeature.tabularFigures()],
+                      ),
                     ),
-                  ),
+                  ],
                 ],
               ),
             ),

--- a/test/widgets/skip_control_test.dart
+++ b/test/widgets/skip_control_test.dart
@@ -66,11 +66,11 @@ void main() {
     expect(ends, 1);
   });
 
-  testWidgets('idle label shows the skip size; holdLabel replaces it', (
+  testWidgets('idle control hides the skip size; holdLabel appears on hold', (
     tester,
   ) async {
     await pumpControl(tester);
-    expect(find.text('10s'), findsOneWidget);
+    expect(find.text('10s'), findsNothing);
 
     await pumpControl(tester, holdLabel: '+45s');
     expect(find.text('+45s'), findsOneWidget);
@@ -79,7 +79,7 @@ void main() {
     // Back to idle (hold released) — the repeating sweep must stop so the
     // test's ticker assertions (and the widget) settle.
     await pumpControl(tester);
-    expect(find.text('10s'), findsOneWidget);
+    expect(find.text('10s'), findsNothing);
     await tester.pumpAndSettle();
   });
 


### PR DESCRIPTION
## Summary
- remove the visible `10s` label from the player skip-back and skip-forward controls
- retain the chevron controls, 10-second tap behavior, hold-to-seek feedback, tooltips, and accessibility labels
- update the widget regression coverage

## Verification
- `dart format --set-exit-if-changed .`
- `flutter analyze --fatal-infos --fatal-warnings`
- `flutter test` (203 tests)