### PR TITLE
Restore purple as the primary accent, keep lime green for success states

### DIFF
--- a/lib/config/theme.dart
+++ b/lib/config/theme.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-/// NullFeed's visual language: quiet, cinematic surfaces with a bright
-/// "signal" accent. The high-contrast accent is reserved for actions and live
-/// state so users can immediately tell what is interactive.
+/// NullFeed's visual language: quiet, cinematic surfaces with a purple
+/// brand accent for actions and interactive state, plus a bright lime
+/// "ready" signal reserved for success states (downloaded, connected).
 class NullFeedTheme {
   NullFeedTheme._();
 
-  static const Color primaryColor = Color(0xFFB8FF5C);
-  static const Color accentColor = Color(0xFF9A8CFF);
+  static const Color primaryColor = Color(0xFF7C4DFF);
+  static const Color accentColor = Color(0xFFB388FF);
   static const Color backgroundColor = Color(0xFF07090D);
   static const Color surfaceColor = Color(0xFF0D1118);
   static const Color cardColor = Color(0xFF131923);
@@ -19,7 +19,7 @@ class NullFeedTheme {
   static const Color textMuted = Color(0xFF8C98A8);
   static const Color dividerColor = Color(0xFF222C39);
   static const Color errorColor = Color(0xFFFF7185);
-  static const Color successColor = Color(0xFF5CE6A8);
+  static const Color successColor = Color(0xFFB8FF5C);
   static const Color warningColor = Color(0xFFFFCC66);
   static const Color progressBackground = Color(0xFF303B49);
   static const Color progressForeground = primaryColor;
@@ -37,7 +37,7 @@ class NullFeedTheme {
       secondary: accentColor,
       surface: surfaceColor,
       error: errorColor,
-      onPrimary: Color(0xFF101508),
+      onPrimary: Colors.white,
       onSecondary: Colors.white,
       onSurface: textPrimary,
       onError: Color(0xFF210006),
@@ -112,7 +112,7 @@ class NullFeedTheme {
       ),
       navigationRailTheme: const NavigationRailThemeData(
         backgroundColor: Colors.transparent,
-        indicatorColor: Color(0x29B8FF5C),
+        indicatorColor: Color(0x297C4DFF),
         selectedIconTheme: IconThemeData(color: primaryColor),
         unselectedIconTheme: IconThemeData(color: textMuted),
         selectedLabelTextStyle: TextStyle(

--- a/lib/widgets/app_ui.dart
+++ b/lib/widgets/app_ui.dart
@@ -39,7 +39,7 @@ class _AmbientGlowPainter extends CustomPainter {
     final primaryPaint = Paint()
       ..shader =
           const RadialGradient(
-            colors: [Color(0x18B8FF5C), Color(0x00B8FF5C)],
+            colors: [Color(0x187C4DFF), Color(0x007C4DFF)],
           ).createShader(
             Rect.fromCircle(
               center: Offset(size.width * 0.84, size.height * 0.06),
@@ -55,7 +55,7 @@ class _AmbientGlowPainter extends CustomPainter {
     final accentPaint = Paint()
       ..shader =
           const RadialGradient(
-            colors: [Color(0x149A8CFF), Color(0x009A8CFF)],
+            colors: [Color(0x10B8FF5C), Color(0x00B8FF5C)],
           ).createShader(
             Rect.fromCircle(
               center: Offset(size.width * 0.08, size.height * 0.72),
@@ -101,7 +101,7 @@ class NullFeedMark extends StatelessWidget {
               borderRadius: BorderRadius.circular(compact ? 12 : 14),
               boxShadow: const [
                 BoxShadow(
-                  color: Color(0x2EB8FF5C),
+                  color: Color(0x2E7C4DFF),
                   blurRadius: 24,
                   spreadRadius: -5,
                 ),
@@ -110,7 +110,7 @@ class NullFeedMark extends StatelessWidget {
             child: Icon(
               Icons.graphic_eq_rounded,
               size: compact ? 22 : 27,
-              color: const Color(0xFF101508),
+              color: Colors.white,
             ),
           ),
           if (showWordmark) ...[
@@ -221,9 +221,7 @@ class QuickActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final foreground = emphasized
-        ? const Color(0xFF101508)
-        : NullFeedTheme.textPrimary;
+    final foreground = emphasized ? Colors.white : NullFeedTheme.textPrimary;
     return Semantics(
       button: true,
       label: label,


### PR DESCRIPTION
## Summary
- Revert the primary accent to the pre-overhaul purple (`0xFF7C4DFF`) with the old lighter purple (`0xFFB388FF`) as `accentColor` — #77 had swapped these to lime green
- Keep the lime green (`0xFFB8FF5C`) where it fits naturally: `successColor` (downloaded/offline pins, healthy connection status) and the lower ambient backdrop glow, so it reads as the "ready" signal
- Restore white foregrounds on primary-filled surfaces (buttons, logo mark, emphasized quick actions) now that the fill is dark purple rather than bright lime

The new dark palette, surfaces, and typography from #77 are untouched — this only re-homes the two accent hues.

## Test plan
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- `flutter test` — 227 passing
- `dart format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)