### PR TITLE
fix(discover): decode recommendations from the backend's nullable 'reason'

### DIFF
--- a/lib/models/recommendation.dart
+++ b/lib/models/recommendation.dart
@@ -10,7 +10,10 @@ abstract class Recommendation with _$Recommendation {
     @JsonKey(name: 'channel_name') required String channelName,
     @JsonKey(name: 'channel_id') String? channelId,
     @JsonKey(name: 'youtube_channel_id') String? youtubeChannelId,
-    required String reasoning,
+    // The backend serves this as nullable `reason` (schemas/feed.py
+    // RecommendationOut); requiring a `reasoning` key made every discover
+    // response fail to decode.
+    @JsonKey(name: 'reason') @Default('') String reasoning,
     @JsonKey(name: 'avatar_url') String? avatarUrl,
     @JsonKey(name: 'banner_url') String? bannerUrl,
     @Default(false) bool dismissed,


### PR DESCRIPTION
The Recommendation model required a `reasoning` JSON key, but the backend serves the field as nullable `reason` (`schemas/feed.py` `RecommendationOut`). Every `GET /api/discover` response failed to decode with `type 'Null' is not a subtype of type 'String'`, so the Explore tab rendered its error card instead of suggestions.

Maps the field with `@JsonKey(name: 'reason')` and defaults it to `''` so a null reason can't break the whole payload. The Dart-side `reasoning` name (and all call sites/tests) are unchanged.

Found while generating store screenshots against the nullfeed-demo server, which mirrors the real backend's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UjT16Qz6fmtx8UYzE9pfY