### PR TITLE
Treat an already-gone recommendation as cleared, not an error

### DIFF
--- a/lib/providers/discover_provider.dart
+++ b/lib/providers/discover_provider.dart
@@ -51,14 +51,25 @@ class DiscoverNotifier extends Notifier<AsyncValue<List<Recommendation>>> {
     }
     try {
       await _api.dismissRecommendation(id);
-    } catch (_) {
-      if (ref.mounted &&
-          requestId == _requestId &&
-          ref.read(activeSessionScopeProvider) == scope &&
-          previous != null) {
-        state = AsyncValue.data(previous);
-      }
+    } on ApiException catch (e) {
+      // The recommendation is already gone (e.g. cleared by the staleness
+      // sweep, or by subscribing to it). The card's job is done — keep it
+      // removed rather than resurrecting it and alarming the user.
+      if (e.statusCode == 404) return;
+      _rollback(requestId, scope, previous);
       rethrow;
+    } catch (_) {
+      _rollback(requestId, scope, previous);
+      rethrow;
+    }
+  }
+
+  void _rollback(int requestId, Object? scope, List<Recommendation>? previous) {
+    if (ref.mounted &&
+        requestId == _requestId &&
+        ref.read(activeSessionScopeProvider) == scope &&
+        previous != null) {
+      state = AsyncValue.data(previous);
     }
   }
 

--- a/test/widgets/home_screen_recommendations_test.dart
+++ b/test/widgets/home_screen_recommendations_test.dart
@@ -143,4 +143,49 @@ void main() {
     await tester.pump(const Duration(seconds: 5));
     await tester.pumpAndSettle();
   });
+
+  testWidgets(
+    'a 404 when clearing the recommendation is treated as already-cleared',
+    (tester) async {
+      when(() => api.getRecommendations()).thenAnswer(
+        (_) async => [
+          makeRecommendation(
+            id: 'r1',
+            channelName: 'Veritasium',
+            youtubeChannelId: 'UC-x',
+          ),
+        ],
+      );
+      when(() => api.getChannels()).thenAnswer((_) async => const <Channel>[]);
+      when(
+        () => api.subscribeToChannel(
+          any(),
+          trackingMode: any(named: 'trackingMode'),
+        ),
+      ).thenAnswer((_) async {});
+      // The recommendation is already gone server-side (e.g. cleared by the
+      // staleness sweep) — dismiss 404s.
+      when(() => api.dismissRecommendation(any())).thenThrow(
+        const ApiException(
+          message: 'Recommendation not found',
+          statusCode: 404,
+        ),
+      );
+
+      await pumpHome(tester);
+      await revealRecommendations(tester);
+      await tester.ensureVisible(find.text('Subscribe'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Subscribe'));
+      await tester.pumpAndSettle();
+
+      // The card is cleared and NO "could not be cleared" error is shown.
+      expect(find.text('Subscribed to Veritasium'), findsOneWidget);
+      expect(find.text('Recommended for you'), findsNothing);
+      expect(find.textContaining('could not be cleared'), findsNothing);
+
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+    },
+  );
 }


### PR DESCRIPTION
## Tester report
Subscribing to a recommendation showed **"Subscribed to X, but the suggestion could not be cleared"** and left the card with a stale Subscribe button.

## Fix
`discoverProvider.dismiss` optimistically removed the card, then on **any** failure rolled it back and rethrew — so a 404 (the recommendation already gone) made the card **reappear** and the screen show the cleanup error. Now a 404 is treated as success: the card stays cleared, nothing is rethrown (other errors keep the rollback + surface). This covers the staleness-sweep race and, together with the backend fix (windoze95/nullfeed-backend#133 — subscribe no longer wipes the whole list), makes the Explore/Home subscribe→clear flow reliable.

## Test plan
New widget test asserts a 404 during clear leaves the card removed with no error toast. `dart format` + `flutter analyze --fatal-infos --fatal-warnings` clean; all 234 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)